### PR TITLE
Use self-hosted Github Runner

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -42,6 +42,12 @@ jobs:
           version-file: .tool-versions
           version-type: strict
 
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4.0.2
+        with:
+          node-version-file: .tool-versions
+          cache: npm
+
       - name: Restore cache
         id: cache
         uses: actions/cache/restore@v4

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,7 +1,11 @@
 name: CI/CD
 
 on:
-  - push
+  push:
+
+  pull_request:
+    branches:
+      - main
 
 env:
   MIX_ENV: test
@@ -13,7 +17,7 @@ permissions:
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     services:
       postgres:
@@ -80,7 +84,7 @@ jobs:
   build:
     name: Build Docker image
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -141,7 +145,7 @@ jobs:
     name: Deploy to staging
     if: github.ref == 'refs/heads/main'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     environment:
       name: staging

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           node-version-file: .tool-versions
           cache: npm
+          cache-dependency-path: assets/package-lock.json
 
       - name: Restore cache
         id: cache

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   test:
     name: Run tests
-    runs-on: self-hosted
+    runs-on: hetzner
 
     services:
       postgres:
@@ -84,7 +84,7 @@ jobs:
   build:
     name: Build Docker image
     needs: test
-    runs-on: self-hosted
+    runs-on: hetzner
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -145,7 +145,7 @@ jobs:
     name: Deploy to staging
     if: github.ref == 'refs/heads/main'
     needs: build
-    runs-on: self-hosted
+    runs-on: hetzner
 
     environment:
       name: staging

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-erlang 26.2.2
-elixir 1.16.1-otp-26
+erlang 26.2.5
+elixir 1.16.3-otp-26
 nodejs 20.11.0
 direnv 2.33.0


### PR DESCRIPTION
The Github Runner is deployed on a Hetzner bare-metal server using k3s. Apart from the unlimited build time, the builds should also be quite a bit faster!

The build is running in a Kubernetes pod using this image: https://github.com/actions/runner/pkgs/container/actions-runner

It should mostly be compatible with the Github runner, but let me know if there are any issues.