### PR TITLE
ui: improved pagination and collection table

### DIFF
--- a/assets/css/components/table.css
+++ b/assets/css/components/table.css
@@ -8,4 +8,8 @@
       }
     }
   }
+
+  .table :where(tbody tr:last-child) {
+    border-bottom-width: 0 !important;
+  }
 }

--- a/lib/data_aggregator_web/components/blocks/header.ex
+++ b/lib/data_aggregator_web/components/blocks/header.ex
@@ -155,7 +155,11 @@ defmodule DataAggregatorWeb.Blocks.Header do
 
   def section_heading(assigns) do
     ~H"""
-    <div class={["w-full", break_size_class(@break_at, @align_items), @class]}>
+    <div class={[
+      "min-h-[33px] w-full sm:min-h-[50px]",
+      break_size_class(@break_at, @align_items),
+      @class
+    ]}>
       <div class={["min-w-0 flex-1", @align_actions && "sm:mt-2"]}>
         <.dynamic_tag
           :if={@title == []}

--- a/lib/data_aggregator_web/components/blocks/secondary_navigation.ex
+++ b/lib/data_aggregator_web/components/blocks/secondary_navigation.ex
@@ -27,7 +27,7 @@ defmodule DataAggregatorWeb.Blocks.SecondaryNavigation do
 
   def secondary_navigation(assigns) do
     ~H"""
-    <div class={["border-black-white/10 bg-base-200/95 relative z-10 border-y backdrop-blur", @class]}>
+    <div class={["border-black-white/10 bg-base-200/95 relative z-20 border-y backdrop-blur", @class]}>
       <nav aria-labelledby={@id} class="py-4">
         <h2 id={@id} class="sr-only">Secondary navigation</h2>
         <ul

--- a/lib/data_aggregator_web/components/components/flash.ex
+++ b/lib/data_aggregator_web/components/components/flash.ex
@@ -123,8 +123,8 @@ defmodule DataAggregatorWeb.Components.Flash do
         class="pointer-events-none fixed inset-0 flex items-end px-4 py-6 sm:items-start sm:p-6"
       >
         <div class="flex w-full flex-col items-center space-y-4 sm:items-end">
-          <.flash kind={:info} title={~t"Success!"m} flash={@flash} timeout={5000} />
-          <.flash kind={:error} title={~t"Error!"m} flash={@flash} timeout={5000} />
+          <.flash kind={:info} title={~t"Success!"m} flash={@flash} timeout={2000} />
+          <.flash kind={:error} title={~t"Error!"m} flash={@flash} timeout={2000} />
           <.flash
             id="client-error"
             kind={:error}

--- a/lib/data_aggregator_web/components/components/pagination.ex
+++ b/lib/data_aggregator_web/components/components/pagination.ex
@@ -5,6 +5,9 @@ defmodule DataAggregatorWeb.Components.Pagination do
 
   use Phoenix.Component
 
+  import DataAggregatorWeb.Gettext
+  import DataAggregatorWeb.Helpers, only: [class_names: 1]
+
   alias Pagify.Meta
 
   @doc """
@@ -19,6 +22,15 @@ defmodule DataAggregatorWeb.Components.Pagination do
     doc: """
     The meta information of the query as returned by the `Pagify` query functions
     """
+
+  attr :position, :string,
+    default: "bottom",
+    values: ~w(top bottom),
+    doc: "The position of the pagination component. Can be `top` or `bottom`."
+
+  attr :class, :string,
+    default: nil,
+    doc: "Additional classes to add to the pagination container."
 
   attr :path, :any,
     default: nil,
@@ -35,38 +47,86 @@ defmodule DataAggregatorWeb.Components.Pagination do
     ~H"""
     <div
       :if={Pagify.Components.Pagination.show_pagination?(@meta)}
-      class="border-black-white/10 flex items-center justify-end space-x-3 border-t px-6 py-4 lg:px-8"
+      class={[
+        "border-black-white/10 flex items-baseline justify-between space-x-3 px-6 lg:px-8",
+        @position == "top" && "border-y pb-4",
+        @position == "bottom" && "border-t py-4",
+        @class
+      ]}
     >
-      <DataAggregatorWeb.Components.Dropdown.dropdown id="set_limit" class="dropdown-end dropdown-top">
-        <:summary>
-          <summary class="btn btn-sm">
-            <span><%= @meta.current_limit %></span>
-            <DataAggregatorWeb.Components.Icon.icon name="hero-chevron-down-micro" />
-          </summary>
-        </:summary>
-        <ul class="dropdown-content menu menu-sm bg-base-200 rounded-box border-black-white/10 mb-0.5 w-16 gap-1 border p-2 shadow-2xl">
-          <li>
-            <.link
-              :for={limit <- [15, 25, 50, 75, 100]}
-              patch={
-                Pagify.Components.build_path(@path, @meta.pagify |> Pagify.set_limit(limit),
-                  for: @meta.resource,
-                  default_scopes: @meta.default_scopes
-                )
-              }
-              class={link_class(limit, @meta.current_limit)}
-            >
-              <%= limit %>
-            </.link>
-          </li>
-        </ul>
-      </DataAggregatorWeb.Components.Dropdown.dropdown>
-      <Pagify.Components.pagination meta={@meta} path={@path} />
+      <div class="flex items-baseline justify-between">
+        <span class="text-base-content mr-3 text-sm font-semibold sm:hidden">
+          <%= mgettext(
+            "%{pagination_from} - %{pagination_to} of %{pagination_total}",
+            pagination_from: @meta.current_offset + 1,
+            pagination_to: showing_to(@meta),
+            pagination_total: @meta.total_count
+          ) %>
+        </span>
+        <span class="text-base-content mr-3 text-sm font-semibold max-sm:hidden">
+          <%= mgettext(
+            "Showing %{pagination_from} to %{pagination_to} of %{pagination_total} entries",
+            pagination_from: @meta.current_offset + 1,
+            pagination_to: showing_to(@meta),
+            pagination_total: @meta.total_count
+          ) %>
+        </span>
+      </div>
+
+      <div class="flex items-center justify-end space-x-3">
+        <DataAggregatorWeb.Components.Dropdown.dropdown
+          id={"set_limit_#{@position}"}
+          class={
+            class_names([
+              "dropdown-end",
+              @position == "bottom" && "dropdown-top",
+              @position == "top" && "dropdown-bottom z-10"
+            ])
+          }
+        >
+          <:summary>
+            <summary class="btn btn-sm">
+              <span><%= @meta.current_limit %></span>
+              <DataAggregatorWeb.Components.Icon.icon name="hero-chevron-down-micro" />
+            </summary>
+          </:summary>
+          <ul class={[
+            "dropdown-content menu menu-sm bg-base-200 rounded-box border-black-white/10 w-16 gap-1 border p-2 shadow-2xl",
+            @position == "top" && "mt-0.5",
+            @position == "bottom" && "mb-0.5"
+          ]}>
+            <li>
+              <.link
+                :for={limit <- [15, 25, 50, 75, 100]}
+                patch={
+                  Pagify.Components.build_path(@path, @meta.pagify |> Pagify.set_limit(limit),
+                    for: @meta.resource,
+                    default_scopes: @meta.default_scopes
+                  )
+                }
+                class={link_class(limit, @meta.current_limit)}
+              >
+                <%= limit %>
+              </.link>
+            </li>
+          </ul>
+        </DataAggregatorWeb.Components.Dropdown.dropdown>
+        <Pagify.Components.pagination meta={@meta} path={@path} />
+      </div>
     </div>
     """
   end
 
   defp link_class(number, current_limit) do
     if number == current_limit, do: "active"
+  end
+
+  defp showing_to(%Pagify.Meta{current_limit: limit, current_offset: offset, total_count: total})
+       when limit + offset > total do
+    total
+  end
+
+  defp showing_to(%Pagify.Meta{current_limit: limit, current_offset: offset}) do
+    limit + offset
   end
 end

--- a/lib/data_aggregator_web/live/collection_live/components.ex
+++ b/lib/data_aggregator_web/live/collection_live/components.ex
@@ -1,0 +1,68 @@
+defmodule DataAggregatorWeb.CollectionLive.Components do
+  @moduledoc """
+  This module contains components for the collection live view.
+  """
+
+  use DataAggregatorWeb, :html
+
+  alias DataAggregator.Records.Collection
+
+  @states AshStateMachine.Info.state_machine_all_states(Collection)
+
+  attr :collection, Collection, required: false
+  attr :state, :atom, required: false, values: @states
+
+  def collection_state_badge(%{collection: collection} = assigns) when is_struct(collection) do
+    assigns
+    |> assign(:state, collection.state)
+    |> assign(:collection, nil)
+    |> collection_state_badge()
+  end
+
+  def collection_state_badge(assigns) do
+    ~H"""
+    <.badge class="pr-3" color={state_color(@state)}>
+      <.collection_state_icon state={@state} />
+      <span><%= state_translation(@state) %></span>
+    </.badge>
+    """
+  end
+
+  defp state_color(state) do
+    if state == :idle do
+      "green"
+    else
+      "blue"
+    end
+  end
+
+  attr :state, :atom, required: true, values: @states
+
+  defp collection_state_icon(%{state: state} = assigns) do
+    {icon, class} = collection_state_icon_class(state)
+    assigns = assign(assigns, icon: icon, class: class)
+
+    ~H"""
+    <.icon name={@icon} class={class_names(["size-5", @class])} />
+    """
+  end
+
+  defp collection_state_icon_class(state) do
+    if state == :idle do
+      {"hero-clock-solid", "text-base-content opacity-60"}
+    else
+      {"hero-cog-6-tooth-solid", "text-info animate-spin"}
+    end
+  end
+
+  defp state_translation(state) do
+    case state do
+      :importing -> ~t"Importing"m
+      :exporting -> ~t"Exporting"m
+      :encoding -> ~t"Encoding"m
+      :fast_track_publishing -> ~t"Publishing"m
+      :approving -> ~t"Approving"m
+      _ -> ~t"Ready"m
+    end
+  end
+end

--- a/lib/data_aggregator_web/live/collection_live/form_component.ex
+++ b/lib/data_aggregator_web/live/collection_live/form_component.ex
@@ -69,6 +69,7 @@ defmodule DataAggregatorWeb.CollectionLive.FormComponent do
               field={@form[:description]}
               label={~t"Description"m}
               placeholder={~t"Description"m}
+              rows="4"
             />
           </.fieldgroup>
           <:actions modal>

--- a/lib/data_aggregator_web/live/collection_live/index.ex
+++ b/lib/data_aggregator_web/live/collection_live/index.ex
@@ -4,6 +4,7 @@ defmodule DataAggregatorWeb.CollectionLive.Index do
   use DataAggregatorWeb, :live_view
   use DataAggregatorWeb.CollectionLive.Subscriptions
 
+  import DataAggregatorWeb.CollectionLive.Components, only: [collection_state_badge: 1]
   import DataAggregatorWeb.CollectionLive.Helpers
   import DataAggregatorWeb.Layouts.Primary, only: [page: 1]
 
@@ -67,6 +68,9 @@ defmodule DataAggregatorWeb.CollectionLive.Index do
         </:col>
         <:col :let={{_id, collection}} field={:code} label={~t"Code"m}>
           <%= collection.code %>
+        </:col>
+        <:col :let={{_id, collection}} field={:state} label={~t"State"m} class="text-center">
+          <.collection_state_badge collection={collection} />
         </:col>
         <:col :let={{_id, collection}} label={~t"Institution"m}>
           <%= collection.institution %>

--- a/lib/data_aggregator_web/live/collection_live/record/index.ex
+++ b/lib/data_aggregator_web/live/collection_live/record/index.ex
@@ -226,7 +226,7 @@ defmodule DataAggregatorWeb.CollectionLive.Record.Index do
               <span class="max-sm:hidden"><%= ~t"Actions"m %></span>
             </summary>
           </:summary>
-          <ul class="dropdown-content menu menu-sm bg-base-200 rounded-box border-black-white/10 top-px z-10 mt-14 w-44 gap-1 border p-2 shadow-2xl">
+          <ul class="dropdown-content menu menu-sm bg-base-200 rounded-box border-black-white/10 top-px z-20 mt-14 w-44 gap-1 border p-2 shadow-2xl">
             <li :for={{label, icon, action, alert} <- @actions}>
               <button
                 phx-click={action}

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -11,19 +11,19 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:77
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:78
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:118
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:119
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Collection created successfully"
 msgstr "Sammlung erfolgreich erstellt"
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:119
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:120
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Collection updated successfully"
@@ -41,88 +41,88 @@ msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Use this form to manage collections in your database."
 msgstr "Benutze dieses Formular, um Sammlungen in deiner Datenbank zu verwalten."
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:121
-#: lib/data_aggregator_web/live/collection_live/index.ex:153
+#: lib/data_aggregator_web/live/collection_live/index.ex:125
+#: lib/data_aggregator_web/live/collection_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Are you sure?"
 msgstr "Bist Du sicher?"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:68
+#: lib/data_aggregator_web/live/collection_live/index.ex:69
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Code"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:189
+#: lib/data_aggregator_web/live/collection_live/index.ex:193
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Collection deleted successfully"
 msgstr "Sammlung erfolgreich gelöscht"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:39
-#: lib/data_aggregator_web/live/collection_live/index.ex:163
+#: lib/data_aggregator_web/live/collection_live/index.ex:40
+#: lib/data_aggregator_web/live/collection_live/index.ex:167
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Collections"
 msgstr "Sammlungen"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:120
+#: lib/data_aggregator_web/live/collection_live/index.ex:124
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:113
+#: lib/data_aggregator_web/live/collection_live/index.ex:117
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:175
+#: lib/data_aggregator_web/live/collection_live/index.ex:179
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Edit Collection"
 msgstr "Sammlung bearbeiten"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:71
+#: lib/data_aggregator_web/live/collection_live/index.ex:75
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Institution"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:60
+#: lib/data_aggregator_web/live/collection_live/index.ex:61
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Name"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:169
+#: lib/data_aggregator_web/live/collection_live/index.ex:173
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "New Collection"
 msgstr "Neue Sammlung"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:43
-#: lib/data_aggregator_web/live/collection_live/index.ex:202
+#: lib/data_aggregator_web/live/collection_live/index.ex:44
+#: lib/data_aggregator_web/live/collection_live/index.ex:206
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "New collection"
 msgstr "Neue Sammlung"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:77
+#: lib/data_aggregator_web/live/collection_live/index.ex:81
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Progress"
 msgstr "Fortschritt"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:95
+#: lib/data_aggregator_web/live/collection_live/index.ex:99
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Records count / est."
 msgstr "Einträge / geschätzt"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:100
+#: lib/data_aggregator_web/live/collection_live/index.ex:104
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Updated At"
@@ -865,13 +865,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Summary"
 msgid "Import started in background"
 msgstr "Import im Hintergrund gestartet"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:201
+#: lib/data_aggregator_web/live/collection_live/index.ex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Get started by adding a new collection."
 msgstr "Beginne, indem Du einen neuen Eintrag erstellst."
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:200
+#: lib/data_aggregator_web/live/collection_live/index.ex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "No collections"
@@ -1131,7 +1131,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "This will also delete the following associations:"
 msgstr "Dies wird auch die folgenden Verknüpfungen löschen:"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:44
+#: lib/data_aggregator_web/live/collection_live/index.ex:45
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Add"
@@ -1876,7 +1876,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:108
+#: lib/data_aggregator_web/live/collection_live/index.ex:112
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Actions"
@@ -2393,13 +2393,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Export.Subscriptions"
 msgid "The export has been completed"
 msgstr "Der Export wurde abgeschlossen"
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:86
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:87
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Create collection"
 msgstr "Sammlung speichern"
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:87
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:88
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Update collection"
@@ -2441,7 +2441,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Subscriptions"
 msgid "The import has been completed"
 msgstr "Der Import wurde abgeschlossen"
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:154
+#: lib/data_aggregator_web/live/collection_live/index.ex:158
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Yes, delete collection"
@@ -2607,3 +2607,57 @@ msgstr "Du bist dabei %{rows_count} Einträge zu exportieren. Bitte wähle die S
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "According to IUCN an endangered species"
 msgstr "Gemäss IUCN eine bedrohte Spezies"
+
+#: lib/data_aggregator_web/components/components/pagination.ex:67
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.Components.Pagination"
+msgid "Showing %{pagination_from} to %{pagination_to} of %{pagination_total} entries"
+msgstr "Zeige %{pagination_from} bis %{pagination_to} von %{pagination_total} Einträgen"
+
+#: lib/data_aggregator_web/components/components/pagination.ex:59
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.Components.Pagination"
+msgid "%{pagination_from} - %{pagination_to} of %{pagination_total}"
+msgstr "%{pagination_from} - %{pagination_to} von %{pagination_total}"
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:64
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Approving"
+msgstr "Genehmigend"
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:62
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Encoding"
+msgstr "Enkodierend"
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:61
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Exporting"
+msgstr "Exportierend"
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:60
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Importing"
+msgstr "Importierend"
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:63
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Publishing"
+msgstr "Veröffentlichend"
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:65
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Ready"
+msgstr "Bereit"
+
+#: lib/data_aggregator_web/live/collection_live/index.ex:72
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Index"
+msgid "State"
+msgstr "Status"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,19 +11,19 @@
 msgid ""
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:77
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:78
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Cancel"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:118
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:119
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Collection created successfully"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:119
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:120
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Collection updated successfully"
@@ -41,88 +41,88 @@ msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Use this form to manage collections in your database."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:121
-#: lib/data_aggregator_web/live/collection_live/index.ex:153
+#: lib/data_aggregator_web/live/collection_live/index.ex:125
+#: lib/data_aggregator_web/live/collection_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Are you sure?"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:68
+#: lib/data_aggregator_web/live/collection_live/index.ex:69
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Code"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:189
+#: lib/data_aggregator_web/live/collection_live/index.ex:193
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Collection deleted successfully"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:39
-#: lib/data_aggregator_web/live/collection_live/index.ex:163
+#: lib/data_aggregator_web/live/collection_live/index.ex:40
+#: lib/data_aggregator_web/live/collection_live/index.ex:167
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Collections"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:120
+#: lib/data_aggregator_web/live/collection_live/index.ex:124
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Delete"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:113
+#: lib/data_aggregator_web/live/collection_live/index.ex:117
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Edit"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:175
+#: lib/data_aggregator_web/live/collection_live/index.ex:179
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Edit Collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:71
+#: lib/data_aggregator_web/live/collection_live/index.ex:75
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Institution"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:60
+#: lib/data_aggregator_web/live/collection_live/index.ex:61
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Name"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:169
+#: lib/data_aggregator_web/live/collection_live/index.ex:173
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "New Collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:43
-#: lib/data_aggregator_web/live/collection_live/index.ex:202
+#: lib/data_aggregator_web/live/collection_live/index.ex:44
+#: lib/data_aggregator_web/live/collection_live/index.ex:206
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "New collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:77
+#: lib/data_aggregator_web/live/collection_live/index.ex:81
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Progress"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:95
+#: lib/data_aggregator_web/live/collection_live/index.ex:99
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Records count / est."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:100
+#: lib/data_aggregator_web/live/collection_live/index.ex:104
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Updated At"
@@ -865,13 +865,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Summary"
 msgid "Import started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:201
+#: lib/data_aggregator_web/live/collection_live/index.ex:205
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Get started by adding a new collection."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:200
+#: lib/data_aggregator_web/live/collection_live/index.ex:204
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "No collections"
@@ -1131,7 +1131,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "This will also delete the following associations:"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:44
+#: lib/data_aggregator_web/live/collection_live/index.ex:45
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Add"
@@ -1876,7 +1876,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Actions"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:108
+#: lib/data_aggregator_web/live/collection_live/index.ex:112
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Actions"
@@ -2393,13 +2393,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Export.Subscriptions"
 msgid "The export has been completed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:86
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:87
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Create collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:87
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:88
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Update collection"
@@ -2441,7 +2441,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Subscriptions"
 msgid "The import has been completed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:154
+#: lib/data_aggregator_web/live/collection_live/index.ex:158
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Yes, delete collection"
@@ -2606,4 +2606,58 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "According to IUCN an endangered species"
+msgstr ""
+
+#: lib/data_aggregator_web/components/components/pagination.ex:67
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.Components.Pagination"
+msgid "Showing %{pagination_from} to %{pagination_to} of %{pagination_total} entries"
+msgstr ""
+
+#: lib/data_aggregator_web/components/components/pagination.ex:59
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.Components.Pagination"
+msgid "%{pagination_from} - %{pagination_to} of %{pagination_total}"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:64
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Approving"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:62
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Encoding"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:61
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Exporting"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:60
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Importing"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:63
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Publishing"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:65
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Ready"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/index.ex:72
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Index"
+msgid "State"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -11,19 +11,19 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:77
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:78
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Cancel"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:118
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:119
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Collection created successfully"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:119
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:120
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Collection updated successfully"
@@ -41,88 +41,88 @@ msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Use this form to manage collections in your database."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:121
-#: lib/data_aggregator_web/live/collection_live/index.ex:153
+#: lib/data_aggregator_web/live/collection_live/index.ex:125
+#: lib/data_aggregator_web/live/collection_live/index.ex:157
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Are you sure?"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:68
+#: lib/data_aggregator_web/live/collection_live/index.ex:69
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Code"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:189
+#: lib/data_aggregator_web/live/collection_live/index.ex:193
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Collection deleted successfully"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:39
-#: lib/data_aggregator_web/live/collection_live/index.ex:163
+#: lib/data_aggregator_web/live/collection_live/index.ex:40
+#: lib/data_aggregator_web/live/collection_live/index.ex:167
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Collections"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:120
+#: lib/data_aggregator_web/live/collection_live/index.ex:124
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Delete"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:113
+#: lib/data_aggregator_web/live/collection_live/index.ex:117
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Edit"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:175
+#: lib/data_aggregator_web/live/collection_live/index.ex:179
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Edit Collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:71
+#: lib/data_aggregator_web/live/collection_live/index.ex:75
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Institution"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:60
+#: lib/data_aggregator_web/live/collection_live/index.ex:61
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Name"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:169
+#: lib/data_aggregator_web/live/collection_live/index.ex:173
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "New Collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:43
-#: lib/data_aggregator_web/live/collection_live/index.ex:202
+#: lib/data_aggregator_web/live/collection_live/index.ex:44
+#: lib/data_aggregator_web/live/collection_live/index.ex:206
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "New collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:77
+#: lib/data_aggregator_web/live/collection_live/index.ex:81
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Progress"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:95
+#: lib/data_aggregator_web/live/collection_live/index.ex:99
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Records count / est."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:100
+#: lib/data_aggregator_web/live/collection_live/index.ex:104
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Updated At"
@@ -865,13 +865,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Summary"
 msgid "Import started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:201
+#: lib/data_aggregator_web/live/collection_live/index.ex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Get started by adding a new collection."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:200
+#: lib/data_aggregator_web/live/collection_live/index.ex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "No collections"
@@ -1131,7 +1131,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "This will also delete the following associations:"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:44
+#: lib/data_aggregator_web/live/collection_live/index.ex:45
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Add"
@@ -1876,7 +1876,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Actions"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:108
+#: lib/data_aggregator_web/live/collection_live/index.ex:112
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Actions"
@@ -2393,13 +2393,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Export.Subscriptions"
 msgid "The export has been completed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:86
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:87
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Create collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:87
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:88
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Update collection"
@@ -2441,7 +2441,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Subscriptions"
 msgid "The import has been completed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:154
+#: lib/data_aggregator_web/live/collection_live/index.ex:158
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Yes, delete collection"
@@ -2606,4 +2606,58 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "According to IUCN an endangered species"
+msgstr ""
+
+#: lib/data_aggregator_web/components/components/pagination.ex:67
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.Components.Pagination"
+msgid "Showing %{pagination_from} to %{pagination_to} of %{pagination_total} entries"
+msgstr ""
+
+#: lib/data_aggregator_web/components/components/pagination.ex:59
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.Components.Pagination"
+msgid "%{pagination_from} - %{pagination_to} of %{pagination_total}"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:64
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Approving"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:62
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Encoding"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:61
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Exporting"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:60
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Importing"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:63
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Publishing"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:65
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Ready"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/index.ex:72
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Index"
+msgid "State"
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -11,19 +11,19 @@ msgstr ""
 "Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n>1);\n"
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:77
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:78
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Cancel"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:118
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:119
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Collection created successfully"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:119
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:120
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Collection updated successfully"
@@ -41,88 +41,88 @@ msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Use this form to manage collections in your database."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:121
-#: lib/data_aggregator_web/live/collection_live/index.ex:153
+#: lib/data_aggregator_web/live/collection_live/index.ex:125
+#: lib/data_aggregator_web/live/collection_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Are you sure?"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:68
+#: lib/data_aggregator_web/live/collection_live/index.ex:69
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Code"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:189
+#: lib/data_aggregator_web/live/collection_live/index.ex:193
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Collection deleted successfully"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:39
-#: lib/data_aggregator_web/live/collection_live/index.ex:163
+#: lib/data_aggregator_web/live/collection_live/index.ex:40
+#: lib/data_aggregator_web/live/collection_live/index.ex:167
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Collections"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:120
+#: lib/data_aggregator_web/live/collection_live/index.ex:124
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Delete"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:113
+#: lib/data_aggregator_web/live/collection_live/index.ex:117
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Edit"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:175
+#: lib/data_aggregator_web/live/collection_live/index.ex:179
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Edit Collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:71
+#: lib/data_aggregator_web/live/collection_live/index.ex:75
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Institution"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:60
+#: lib/data_aggregator_web/live/collection_live/index.ex:61
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Name"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:169
+#: lib/data_aggregator_web/live/collection_live/index.ex:173
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "New Collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:43
-#: lib/data_aggregator_web/live/collection_live/index.ex:202
+#: lib/data_aggregator_web/live/collection_live/index.ex:44
+#: lib/data_aggregator_web/live/collection_live/index.ex:206
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "New collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:77
+#: lib/data_aggregator_web/live/collection_live/index.ex:81
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Progress"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:95
+#: lib/data_aggregator_web/live/collection_live/index.ex:99
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Records count / est."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:100
+#: lib/data_aggregator_web/live/collection_live/index.ex:104
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Updated At"
@@ -865,13 +865,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Summary"
 msgid "Import started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:201
+#: lib/data_aggregator_web/live/collection_live/index.ex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Get started by adding a new collection."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:200
+#: lib/data_aggregator_web/live/collection_live/index.ex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "No collections"
@@ -1131,7 +1131,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "This will also delete the following associations:"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:44
+#: lib/data_aggregator_web/live/collection_live/index.ex:45
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Add"
@@ -1876,7 +1876,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Actions"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:108
+#: lib/data_aggregator_web/live/collection_live/index.ex:112
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Actions"
@@ -2393,13 +2393,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Export.Subscriptions"
 msgid "The export has been completed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:86
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:87
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Create collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/form_component.ex:87
+#: lib/data_aggregator_web/live/collection_live/form_component.ex:88
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Update collection"
@@ -2441,7 +2441,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Subscriptions"
 msgid "The import has been completed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/index.ex:154
+#: lib/data_aggregator_web/live/collection_live/index.ex:158
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Index"
 msgid "Yes, delete collection"
@@ -2606,4 +2606,58 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "According to IUCN an endangered species"
+msgstr ""
+
+#: lib/data_aggregator_web/components/components/pagination.ex:67
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.Components.Pagination"
+msgid "Showing %{pagination_from} to %{pagination_to} of %{pagination_total} entries"
+msgstr ""
+
+#: lib/data_aggregator_web/components/components/pagination.ex:59
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.Components.Pagination"
+msgid "%{pagination_from} - %{pagination_to} of %{pagination_total}"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:64
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Approving"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:62
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Encoding"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:61
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Exporting"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:60
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Importing"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:63
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Publishing"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/components.ex:65
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Components"
+msgid "Ready"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/index.ex:72
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Index"
+msgid "State"
 msgstr ""

--- a/storybook/collections/collection_state_badge.story.exs
+++ b/storybook/collections/collection_state_badge.story.exs
@@ -1,0 +1,23 @@
+defmodule Storybook.Collections.CollectionStateBadge do
+  @moduledoc false
+  use PhoenixStorybook.Story, :component
+
+  alias DataAggregatorWeb.CollectionLive.Components
+
+  def function, do: &Components.collection_state_badge/1
+
+  def variations do
+    for state <- available_states() do
+      %Variation{
+        id: state,
+        attributes: %{
+          state: state
+        }
+      }
+    end
+  end
+
+  defp available_states do
+    AshStateMachine.Info.state_machine_all_states(DataAggregator.Records.Collection)
+  end
+end


### PR DESCRIPTION
- [x] added info text "Showing x to y of z entries" to pagination so we have some information about the total number of entries for the current filter and which are displayed
- [x] added state badge to collection index table (this is mostly for debugging purposes and can be removed later if wished so). currently, if there are any error logs due to collection actions I always have to click through all collections to check which one is currently in "action"