### PR TITLE
pruner config: decrease interval time, purge more per run

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -80,7 +80,7 @@ config :ex_cldr,
 config :data_aggregator, Oban,
   repo: DataAggregator.Repo,
   plugins: [{Oban.Plugins.Pruner, max_age: 5, limit: 2000, interval: 5_000}],
-  queues: [imports: 1, encoders: 1, exports: 1, publications: 1, publication_verifications: 1]
+  queues: [imports: 1, encoders: 1, exports: 1, publications: 1, publication_verifications: 0]
 
 # Configures the mailer
 #

--- a/config/config.exs
+++ b/config/config.exs
@@ -79,7 +79,7 @@ config :ex_cldr,
 # Configure Oban job queues
 config :data_aggregator, Oban,
   repo: DataAggregator.Repo,
-  plugins: [{Oban.Plugins.Pruner, max_age: 5, limit: 1000, interval: 10_000}],
+  plugins: [{Oban.Plugins.Pruner, max_age: 5, limit: 2000, interval: 5_000}],
   queues: [imports: 1, encoders: 1, exports: 1, publications: 1, publication_verifications: 1]
 
 # Configures the mailer


### PR DESCRIPTION
make purging faster so, we're ahead of purging when a huge amount of jobs are finished at the same time and oban_jobs table doesn't build up too big