### PR TITLE
fix(encoding): do not abort if a strategy fails

### DIFF
--- a/lib/data_aggregator/records/encoding/encoded_record.ex
+++ b/lib/data_aggregator/records/encoding/encoded_record.ex
@@ -72,7 +72,12 @@ defmodule DataAggregator.Records.EncodedRecord do
       argument :record, :struct, allow_nil?: false
 
       upsert? true
-      upsert_fields [:extra_data | DarwinCore.Schema.prefixed_attribute_names()]
+
+      upsert_fields [
+                      :extra_data,
+                      :iucn_redlist_category
+                    ] ++ DarwinCore.Schema.prefixed_attribute_names()
+
       upsert_identity :record_mte_catalog_number
 
       change Encoding.Changes.SetMandatoryAttributes

--- a/lib/data_aggregator/records/encoding/strategies/iucn_redlist_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/iucn_redlist_strategy.ex
@@ -28,10 +28,10 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
       {:ok, encoded_record} ->
         {:ok, encoded_record}
 
-      {:error, error} ->
+      {:error, error, encoded_record} ->
         handle_error(encoded_record.id, error)
 
-        {:error, error}
+        {:error, error, encoded_record}
     end
   rescue
     error ->
@@ -54,6 +54,8 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
       else
         {:ok, Strategy.update_encoded_record(response.body, encoded_record, @output_attributes)}
       end
+    else
+      error -> {:error, error, encoded_record}
     end
   end
 
@@ -79,7 +81,9 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
   end
 
   @spec handle_error(String.t(), any()) :: :ok
-  defp handle_error(record_id, error) do
-    Logger.warning("Error while encoding the record #{record_id} with the gbif iucn redlist catalog: #{inspect(error)}")
+  defp handle_error(encoded_record_id, error) do
+    Logger.warning(
+      "Error while encoding the encoded_record #{encoded_record_id} with the gbif iucn redlist catalog: #{inspect(error)}"
+    )
   end
 end

--- a/lib/data_aggregator/records/encoding/strategies/iucn_redlist_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/iucn_redlist_strategy.ex
@@ -37,7 +37,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
     error ->
       handle_error(encoded_record.id, error)
 
-      {:error, error}
+      {:error, error, encoded_record}
   end
 
   @spec process_encoded_record(EncodedRecord.t()) :: EncodingResult.t()
@@ -55,7 +55,9 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
         {:ok, Strategy.update_encoded_record(response.body, encoded_record, @output_attributes)}
       end
     else
-      error -> {:error, error, encoded_record}
+      e ->
+        {:error, error} = e
+        {:error, error, encoded_record}
     end
   end
 
@@ -63,9 +65,9 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
 
   defp ensure_response({:error, error}, taxon_id) do
     msg =
-      "Error while iucn redlist status on gbif api using taxon_id: #{taxon_id}. #{inspect(error)}"
+      "Error while iucn redlist status on gbif api using taxon_id: #{taxon_id}."
 
-    Logger.warning(msg)
+    Logger.warning("#{msg} #{inspect(error)}")
 
     {:error, msg}
   end
@@ -73,9 +75,9 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
   defp ensure_status(response) when response.status == 200 or response.status == 204, do: :ok
 
   defp ensure_status(response) do
-    msg = "Non 200 status code from gbif iucn redlist api with message: #{inspect(response)}"
+    msg = "Non 200 status code from gbif iucn redlist api."
 
-    Logger.warning(msg)
+    Logger.warning("#{msg} Message: #{inspect(response)}")
 
     {:error, msg}
   end
@@ -83,7 +85,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
   @spec handle_error(String.t(), any()) :: :ok
   defp handle_error(encoded_record_id, error) do
     Logger.warning(
-      "Error while encoding the encoded_record #{encoded_record_id} with the gbif iucn redlist catalog: #{inspect(error)}"
+      "[iucn_redlist_strategy] Error while encoding the encoded_record #{encoded_record_id} with the gbif iucn redlist catalog: #{inspect(error)}"
     )
   end
 end

--- a/lib/data_aggregator/records/encoding/strategies/iucn_redlist_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/iucn_redlist_strategy.ex
@@ -44,6 +44,9 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
   defp process_encoded_record(encoded_record) do
     taxon_id = encoded_record |> Map.get(@input_attribute, "") |> to_string()
 
+    # early return if taxon_id is empty
+    if taxon_id === "", do: raise("taxon_id is empty")
+
     with {:ok, response} <-
            taxon_id
            |> Gbif.RestAPI.get_iucn_redlist_category()
@@ -85,7 +88,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
   @spec handle_error(String.t(), any()) :: :ok
   defp handle_error(encoded_record_id, error) do
     Logger.warning(
-      "[iucn_redlist_strategy] Error while encoding the encoded_record #{encoded_record_id} with the gbif iucn redlist catalog: #{inspect(error)}"
+      "[gbif_iucn_redlist] Error while encoding the encoded_record #{encoded_record_id} with the gbif iucn redlist catalog: #{inspect(error)}"
     )
   end
 end

--- a/lib/data_aggregator/records/encoding/strategies/location/forward_geo_encoding_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/location/forward_geo_encoding_strategy.ex
@@ -168,6 +168,8 @@ defmodule DataAggregator.Records.Encoding.Strategy.ForwardGeoEncodingStrategy do
 
   @spec handle_error(String.t(), map()) :: :ok
   defp handle_error(encoded_record_id, error) do
-    Logger.warning("Error while encoding the encoded_record #{encoded_record_id} with the geo api: #{inspect(error)}")
+    Logger.warning(
+      "[forward_geo_encoding_strategy] Error while encoding the encoded_record #{encoded_record_id} with the geo api: #{inspect(error)}"
+    )
   end
 end

--- a/lib/data_aggregator/records/encoding/strategies/location/forward_geo_encoding_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/location/forward_geo_encoding_strategy.ex
@@ -169,7 +169,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.ForwardGeoEncodingStrategy do
   @spec handle_error(String.t(), map()) :: :ok
   defp handle_error(encoded_record_id, error) do
     Logger.warning(
-      "[forward_geo_encoding_strategy] Error while encoding the encoded_record #{encoded_record_id} with the geo api: #{inspect(error)}"
+      "[geo_forward] Error while encoding the encoded_record #{encoded_record_id} with the geo api: #{inspect(error)}"
     )
   end
 end

--- a/lib/data_aggregator/records/encoding/strategies/location/forward_geo_encoding_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/location/forward_geo_encoding_strategy.ex
@@ -28,30 +28,30 @@ defmodule DataAggregator.Records.Encoding.Strategy.ForwardGeoEncodingStrategy do
 
     if longitude != nil && latitude != nil do
       Logger.debug(
-        "The record #{encoded_record.id} already has coordinates, therefore a forward encoding will not provide better data. We will not forward encode towards the geo api."
+        "The encoded_record #{encoded_record.id} already has coordinates, therefore a forward encoding will not provide better data. We will not forward encode towards the geo api."
       )
 
       {:ok, encoded_record}
     else
-      case process_record(encoded_record) do
+      case process_encoded_record(encoded_record) do
         {:ok, encoded_record} ->
           {:ok, encoded_record}
 
-        {:error, error} ->
+        {:error, error, encoded_record} ->
           handle_error(encoded_record.id, error)
 
-          {:error, error}
+          {:error, error, encoded_record}
       end
     end
   rescue
     error ->
       handle_error(encoded_record.id, error)
 
-      {:error, error}
+      {:error, error, encoded_record}
   end
 
-  @spec process_record(EncodedRecord.t()) :: EncodingResult.t()
-  defp process_record(encoded_record) do
+  @spec process_encoded_record(EncodedRecord.t()) :: EncodingResult.t()
+  defp process_encoded_record(encoded_record) do
     {
       :ok,
       encoded_record
@@ -61,11 +61,11 @@ defmodule DataAggregator.Records.Encoding.Strategy.ForwardGeoEncodingStrategy do
     }
   catch
     error ->
-      {:error, error}
+      {:error, error, encoded_record}
   end
 
   @spec build_params(EncodedRecord.t()) :: {:ok, list()} | {:error, any()}
-  defp build_params(record) do
+  defp build_params(encoded_record) do
     api_key =
       System.get_env("OPEN_CAGE_DATA_API_KEY") ||
         throw("No open cage data api key found in the environment variables. set one under OPEN_CAGE_DATA_API_KEY")
@@ -73,17 +73,19 @@ defmodule DataAggregator.Records.Encoding.Strategy.ForwardGeoEncodingStrategy do
     # we want to encode the location if we have at least one of the following fields,
     # otherwise we would get a way too generic response
     q =
-      if record.loc_locality || record.loc_municipality do
+      if encoded_record.loc_locality || encoded_record.loc_municipality do
         [
-          record.loc_locality,
-          record.loc_municipality,
-          record.loc_state_province,
-          record.loc_country
+          encoded_record.loc_locality,
+          encoded_record.loc_municipality,
+          encoded_record.loc_state_province,
+          encoded_record.loc_country
         ]
         |> Enum.reject(&is_nil/1)
         |> Enum.join(", ")
       else
-        Logger.debug("no record.loc_locality or record.loc_municipality found on record #{record.id}")
+        Logger.debug(
+          "no encoded_record.loc_locality or encoded_record.loc_municipality found on encoded_record #{encoded_record.id}"
+        )
 
         ""
       end
@@ -92,7 +94,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.ForwardGeoEncodingStrategy do
     case q do
       "" ->
         {:error,
-         "The attributes necessary to forward geo encode were not found on record #{record.id}, we will not encode towards the geo api"}
+         "The attributes necessary to forward geo encode were not found on encoded_record #{encoded_record.id}, we will not encode towards the geo api"}
 
       query ->
         {:ok,
@@ -101,7 +103,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.ForwardGeoEncodingStrategy do
            {:key, api_key},
            {:language, "en"},
            {:no_annotations, 1},
-           {:countrycode, record.loc_country_code}
+           {:countrycode, encoded_record.loc_country_code}
          ]
          |> Enum.reject(&is_nil/1)
          |> Enum.filter(fn {_, value} ->
@@ -165,7 +167,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.ForwardGeoEncodingStrategy do
   end
 
   @spec handle_error(String.t(), map()) :: :ok
-  defp handle_error(record_id, error) do
-    Logger.warning("Error while encoding the record #{record_id} with the geo api: #{inspect(error)}")
+  defp handle_error(encoded_record_id, error) do
+    Logger.warning("Error while encoding the encoded_record #{encoded_record_id} with the geo api: #{inspect(error)}")
   end
 end

--- a/lib/data_aggregator/records/encoding/strategies/location/reverse_geo_encoding_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/location/reverse_geo_encoding_strategy.ex
@@ -233,6 +233,8 @@ defmodule DataAggregator.Records.Encoding.Strategy.ReverseGeoEncodingStrategy do
 
   @spec handle_error(String.t(), map()) :: :ok
   defp handle_error(encoded_record_id, error) do
-    Logger.warning("Error while encoding the encoded_record #{encoded_record_id} with the geo api: #{inspect(error)}")
+    Logger.warning(
+      "[reverse_geo_encoding_strategy] Error while encoding the encoded_record #{encoded_record_id} with the geo api: #{inspect(error)}"
+    )
   end
 end

--- a/lib/data_aggregator/records/encoding/strategies/location/reverse_geo_encoding_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/location/reverse_geo_encoding_strategy.ex
@@ -25,24 +25,24 @@ defmodule DataAggregator.Records.Encoding.Strategy.ReverseGeoEncodingStrategy do
   def apply_strategy(encoded_record) do
     encoded_record = Ash.load!(encoded_record, [:record])
 
-    case process_record(encoded_record) do
+    case process_encoded_record(encoded_record) do
       {:ok, encoded_record} ->
         {:ok, encoded_record}
 
-      {:error, error} ->
+      {:error, error, encoded_record} ->
         handle_error(encoded_record.id, error)
 
-        {:error, error}
+        {:error, error, encoded_record}
     end
   rescue
     error ->
       handle_error(encoded_record.id, error)
 
-      {:error, error}
+      {:error, error, encoded_record}
   end
 
-  @spec process_record(EncodedRecord.t()) :: EncodingResult.t()
-  defp process_record(encoded_record) do
+  @spec process_encoded_record(EncodedRecord.t()) :: EncodingResult.t()
+  defp process_encoded_record(encoded_record) do
     {
       :ok,
       encoded_record
@@ -55,12 +55,12 @@ defmodule DataAggregator.Records.Encoding.Strategy.ReverseGeoEncodingStrategy do
     }
   catch
     error ->
-      {:error, error}
+      {:error, error, encoded_record}
   end
 
   @spec build_params(EncodedRecord.t()) :: {:ok, list()} | {:error, any()}
-  defp build_params(record) do
-    case convert_coordinates(record) do
+  defp build_params(encoded_record) do
+    case convert_coordinates(encoded_record) do
       {:ok, %{n: lat, e: long}} ->
         {:ok, [{:q, "#{lat},#{long}"}]}
 
@@ -70,12 +70,12 @@ defmodule DataAggregator.Records.Encoding.Strategy.ReverseGeoEncodingStrategy do
   end
 
   @spec convert_coordinates(EncodedRecord.t()) :: GeoCoordResult.t()
-  defp convert_coordinates(record) do
-    intl_lat = record.loc_decimal_latitude
-    intl_long = record.loc_decimal_longitude
+  defp convert_coordinates(encoded_record) do
+    intl_lat = encoded_record.loc_decimal_latitude
+    intl_long = encoded_record.loc_decimal_longitude
 
-    swiss_lat = record.loc_swiss_coordinates_y
-    swiss_long = record.loc_swiss_coordinates_x
+    swiss_lat = encoded_record.loc_swiss_coordinates_y
+    swiss_long = encoded_record.loc_swiss_coordinates_x
 
     cond do
       intl_lat != nil and intl_long != nil ->
@@ -85,7 +85,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.ReverseGeoEncodingStrategy do
         {:ok, Coordinates.lv95_to_wgs84!(%Coordinates{n: swiss_lat, e: swiss_long})}
 
       true ->
-        {:error, "no coordinates found on record #{record.id}"}
+        {:error, "no coordinates found on encoded_record #{encoded_record.id}"}
     end
   end
 
@@ -232,7 +232,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.ReverseGeoEncodingStrategy do
   end
 
   @spec handle_error(String.t(), map()) :: :ok
-  defp handle_error(record_id, error) do
-    Logger.warning("Error while encoding the record #{record_id} with the geo api: #{inspect(error)}")
+  defp handle_error(encoded_record_id, error) do
+    Logger.warning("Error while encoding the encoded_record #{encoded_record_id} with the geo api: #{inspect(error)}")
   end
 end

--- a/lib/data_aggregator/records/encoding/strategies/location/reverse_geo_encoding_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/location/reverse_geo_encoding_strategy.ex
@@ -234,7 +234,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.ReverseGeoEncodingStrategy do
   @spec handle_error(String.t(), map()) :: :ok
   defp handle_error(encoded_record_id, error) do
     Logger.warning(
-      "[reverse_geo_encoding_strategy] Error while encoding the encoded_record #{encoded_record_id} with the geo api: #{inspect(error)}"
+      "[geo_reverse] Error while encoding the encoded_record #{encoded_record_id} with the geo api: #{inspect(error)}"
     )
   end
 end

--- a/lib/data_aggregator/records/encoding/strategies/strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/strategy.ex
@@ -67,8 +67,8 @@ defmodule DataAggregator.Records.Encoding.Strategy do
     |> handle_encoding_result(encoded_record, catalog)
   end
 
-  def encode(_record, catalog) do
-    {:error, "no encoding strategy found for catalog: #{inspect(catalog)}"}
+  def encode(record, catalog) do
+    {:error, "no encoding strategy found for catalog: #{inspect(catalog)}", record}
   end
 
   @spec handle_encoding_result(EncodingResult.t(), EncodedRecord.t(), atom()) ::
@@ -90,10 +90,10 @@ defmodule DataAggregator.Records.Encoding.Strategy do
 
         {:ok, unchanged_record}
 
-      {:error, error} ->
+      {:error, error, encoding_result} ->
         create_error_result(attrs, catalog, old_record, error)
 
-        {:error, error}
+        {:error, error, encoding_result}
     end
   end
 
@@ -162,8 +162,8 @@ defmodule DataAggregator.Records.Encoding.Strategy do
           {:ok, new_encoded_record}
         end
 
-      {:error, error} ->
-        {:error, error}
+      {:error, error, encoding_result} ->
+        {:error, error, encoding_result}
     end
   end
 

--- a/lib/data_aggregator/records/encoding/strategies/strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/strategy.ex
@@ -178,31 +178,24 @@ defmodule DataAggregator.Records.Encoding.Strategy do
   #  create an encoded record if it does not exist yet
   @spec create_encoded_record(Record.t()) :: EncodedRecord.t()
   defp create_encoded_record(record) do
-    attributes =
-      [
-        :extra_data,
-        :iucn_redlist_category
-      ] ++ DataAggregator.DarwinCore.Schema.prefixed_attribute_names()
+    case EncodedRecord.get_by_record(record.id) do
+      {:ok, encoded_record} ->
+        encoded_record
 
-    EncodedRecord.create!(
-      record
-      |> Map.from_struct()
-      |> Map.take(attributes)
-      |> Map.put_new_lazy(:record, fn -> record end)
-    )
+      {:error, %Ash.Error.Query.NotFound{}} ->
+        attributes =
+          [
+            :extra_data,
+            :iucn_redlist_category
+          ] ++ DataAggregator.DarwinCore.Schema.prefixed_attribute_names()
 
-    # case EncodedRecord.get_by_record(record.id) do
-    #   {:ok, result} ->
-    #     result
-
-    #   {:error, %Ash.Error.Query.NotFound{}} ->
-    #     EncodedRecord.create!(
-    #       record
-    #       |> Map.from_struct()
-    #       |> Map.take(attributes)
-    #       |> Map.put_new_lazy(:record, fn -> record end)
-    #     )
-    # end
+        EncodedRecord.create!(
+          record
+          |> Map.from_struct()
+          |> Map.take(attributes)
+          |> Map.put_new_lazy(:record, fn -> record end)
+        )
+    end
   end
 
   @spec update_encoded_record(map(), EncodedRecord.t(), list()) :: EncodedRecord.t()

--- a/lib/data_aggregator/records/encoding/strategies/strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/strategy.ex
@@ -2,11 +2,16 @@ defmodule DataAggregator.Records.Encoding.Strategy do
   @moduledoc """
     This module is responsible for encoding records with configured catalogs.
 
+    At this point, the encoded_record must already exist in the database. It
+    is created / upserted during the import process. Thus, we simply
+    fetch the encoded_record from the database and pass it to the encoding.
+
     To encode records with a new catalog, add the catalog to the @catalogs list and
     implement the encode/2 function with the corresponding `when` statement
 
     to keep this module clean, the actual encoding logic is delegated to a
-    strategy module like we do with the `DataAggregator.Records.Encoding.Strategy.GbifTaxonomyStrategy` or the `DataAggregator.Records.Encoding.Strategy.SwissSpeciesStrategy` module
+    strategy module like we do with the `DataAggregator.Records.Encoding.Strategy.GbifTaxonomyStrategy`
+    or the `DataAggregator.Records.Encoding.Strategy.SwissSpeciesStrategy` module
   """
   alias DataAggregator.Records.EncodedRecord
   alias DataAggregator.Records.Encoding.EncodingResult
@@ -21,54 +26,72 @@ defmodule DataAggregator.Records.Encoding.Strategy do
 
   require Logger
 
-  @spec encode(Record.t(), atom()) :: EncodingResult.t()
-  def encode(record, catalog) when catalog == :gbif_taxonomy do
-    encoded_record = create_encoded_record(record)
+  @doc """
+  Attention! For the first catalog we reset the encoded_record to the record's value.
+  As of now, the first catalog is the gbif_taxonomy catalog. If this changes, the
+  first catalog must be updated here as well.
+  """
+  @spec encode(Record.t() | EncodedRecord.t(), atom()) :: EncodingResult.t()
+  def encode(%Record{} = record, catalog) when catalog == :gbif_taxonomy do
+    attributes =
+      [
+        :extra_data,
+        :iucn_redlist_category
+      ] ++ DataAggregator.DarwinCore.Schema.prefixed_attribute_names()
 
+    encoded_record =
+      EncodedRecord.create!(
+        record
+        |> Map.from_struct()
+        |> Map.take(attributes)
+        |> Map.put_new_lazy(:record, fn -> record end)
+      )
+
+    encode(encoded_record, catalog)
+  end
+
+  def encode(%Record{} = record, catalog) do
+    encoded_record = EncodedRecord.get_by_record!(record.id)
+    encode(encoded_record, catalog)
+  end
+
+  def encode(%EncodedRecord{} = encoded_record, catalog) when catalog == :gbif_taxonomy do
     encoded_record
     |> GbifTaxonomyStrategy.apply_strategy()
     |> check_for_changes(encoded_record, catalog)
     |> handle_encoding_result(encoded_record, catalog)
   end
 
-  def encode(record, catalog) when catalog == :swiss_species do
-    encoded_record = create_encoded_record(record)
-
+  def encode(%EncodedRecord{} = encoded_record, catalog) when catalog == :swiss_species do
     encoded_record
     |> SwissSpeciesStrategy.apply_strategy()
     |> check_for_changes(encoded_record, catalog)
     |> handle_encoding_result(encoded_record, catalog)
   end
 
-  def encode(record, catalog) when catalog == :geo_reverse do
-    encoded_record = create_encoded_record(record)
-
+  def encode(%EncodedRecord{} = encoded_record, catalog) when catalog == :geo_reverse do
     encoded_record
     |> ReverseGeoEncodingStrategy.apply_strategy()
     |> check_for_changes(encoded_record, catalog)
     |> handle_encoding_result(encoded_record, catalog)
   end
 
-  def encode(record, catalog) when catalog == :geo_forward do
-    encoded_record = create_encoded_record(record)
-
+  def encode(%EncodedRecord{} = encoded_record, catalog) when catalog == :geo_forward do
     encoded_record
     |> ForwardGeoEncodingStrategy.apply_strategy()
     |> check_for_changes(encoded_record, catalog)
     |> handle_encoding_result(encoded_record, catalog)
   end
 
-  def encode(record, catalog) when catalog == :gbif_iucn_redlist do
-    encoded_record = create_encoded_record(record)
-
+  def encode(%EncodedRecord{} = encoded_record, catalog) when catalog == :gbif_iucn_redlist do
     encoded_record
     |> IUCNRedlistStrategy.apply_strategy()
     |> check_for_changes(encoded_record, catalog)
     |> handle_encoding_result(encoded_record, catalog)
   end
 
-  def encode(record, catalog) do
-    {:error, "no encoding strategy found for catalog: #{inspect(catalog)}", record}
+  def encode(%EncodedRecord{} = encoded_record, catalog) do
+    {:error, "no encoding strategy found for catalog: #{inspect(catalog)}", encoded_record}
   end
 
   @spec handle_encoding_result(EncodingResult.t(), EncodedRecord.t(), atom()) ::
@@ -173,29 +196,6 @@ defmodule DataAggregator.Records.Encoding.Strategy do
 
   defp get_values_used_for_encoding(encoded_record, catalog) do
     Map.take(encoded_record, Catalog.get_input_dwc_attributes(catalog))
-  end
-
-  #  create an encoded record if it does not exist yet
-  @spec create_encoded_record(Record.t()) :: EncodedRecord.t()
-  defp create_encoded_record(record) do
-    case EncodedRecord.get_by_record(record.id) do
-      {:ok, encoded_record} ->
-        encoded_record
-
-      {:error, %Ash.Error.Query.NotFound{}} ->
-        attributes =
-          [
-            :extra_data,
-            :iucn_redlist_category
-          ] ++ DataAggregator.DarwinCore.Schema.prefixed_attribute_names()
-
-        EncodedRecord.create!(
-          record
-          |> Map.from_struct()
-          |> Map.take(attributes)
-          |> Map.put_new_lazy(:record, fn -> record end)
-        )
-    end
   end
 
   @spec update_encoded_record(map(), EncodedRecord.t(), list()) :: EncodedRecord.t()

--- a/lib/data_aggregator/records/encoding/strategies/taxonomy/gbif_taxonomy_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/taxonomy/gbif_taxonomy_strategy.ex
@@ -28,36 +28,36 @@ defmodule DataAggregator.Records.Encoding.Strategy.GbifTaxonomyStrategy do
     query the gbif taxanomy api and return the encoded record
   """
   @spec apply_strategy(EncodedRecord.t()) :: EncodingResult.t()
-  def apply_strategy(record) do
-    process_record(record)
+  def apply_strategy(encoded_record) do
+    process_encoded_record(encoded_record)
   end
 
-  @spec process_record(EncodedRecord.t()) :: EncodingResult.t()
-  defp process_record(record) do
+  @spec process_encoded_record(EncodedRecord.t()) :: EncodingResult.t()
+  defp process_encoded_record(encoded_record) do
     {:ok,
-     record
+     encoded_record
      |> build_request_params()
      |> fetch_match_api()
      |> parse_response()
      |> parse_response_body()
      |> handle_synonym()
-     |> Strategy.update_encoded_record(record, @output_attributes)}
+     |> Strategy.update_encoded_record(encoded_record, @output_attributes)}
   catch
     error ->
-      {:error, error}
+      {:error, error, encoded_record}
   end
 
   @spec build_request_params(EncodedRecord.t()) :: list()
-  defp build_request_params(record) do
+  defp build_request_params(encoded_record) do
     @input_attributes
     |> Enum.map(fn {record_attribute, request_attribute} ->
-      request_value = Map.get(record, record_attribute)
+      request_value = Map.get(encoded_record, record_attribute)
 
       unless request_value == nil do
         {request_attribute, request_value}
       end
     end)
-    |> check_parameters(record)
+    |> check_parameters(encoded_record)
     |> Enum.filter(&(&1 !== nil))
     |> Enum.uniq()
   end

--- a/lib/data_aggregator/records/encoding/strategies/taxonomy/gbif_taxonomy_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/taxonomy/gbif_taxonomy_strategy.ex
@@ -159,7 +159,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.GbifTaxonomyStrategy do
 
   @spec log_and_throw(map()) :: {:ok, map()} | {:error, any()}
   defp log_and_throw(error) do
-    Logger.warning("Error while fetching gbif taxonomy api: #{inspect(error)}")
+    Logger.warning("[gbif_taxonomy_strategy] Error while fetching gbif taxonomy api: #{inspect(error)}")
 
     throw(error)
   end
@@ -194,7 +194,9 @@ defmodule DataAggregator.Records.Encoding.Strategy.GbifTaxonomyStrategy do
         [kingdom: "Plantae"]
 
       true ->
-        Logger.warning("No fallback kingdom found for record #{record.id} on the collection #{record.collection.name}")
+        Logger.warning(
+          "[gbif_taxonomy_strategy] No fallback kingdom found for record #{record.id} on the collection #{record.collection.name}"
+        )
 
         []
     end

--- a/lib/data_aggregator/records/encoding/strategies/taxonomy/gbif_taxonomy_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/taxonomy/gbif_taxonomy_strategy.ex
@@ -159,7 +159,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.GbifTaxonomyStrategy do
 
   @spec log_and_throw(map()) :: {:ok, map()} | {:error, any()}
   defp log_and_throw(error) do
-    Logger.warning("[gbif_taxonomy_strategy] Error while fetching gbif taxonomy api: #{inspect(error)}")
+    Logger.warning("[gbif_taxonomy] Error while fetching gbif taxonomy api: #{inspect(error)}")
 
     throw(error)
   end
@@ -195,7 +195,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.GbifTaxonomyStrategy do
 
       true ->
         Logger.warning(
-          "[gbif_taxonomy_strategy] No fallback kingdom found for record #{record.id} on the collection #{record.collection.name}"
+          "[gbif_taxonomy] No fallback kingdom found for record #{record.id} on the collection #{record.collection.name}"
         )
 
         []

--- a/lib/data_aggregator/records/encoding/strategies/taxonomy/swiss_species_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/taxonomy/swiss_species_strategy.ex
@@ -42,6 +42,11 @@ defmodule DataAggregator.Records.Encoding.Strategy.SwissSpeciesStrategy do
 
   @spec process_encoded_record(EncodedRecord.t()) :: EncodingResult.t()
   defp process_encoded_record(encoded_record) do
+    taxon_id = Map.get(encoded_record, @input_attribute)
+
+    # early return if taxon_id is empty
+    if taxon_id === nil, do: raise("taxon_id is empty")
+
     case SwissSpecies.get_by_usage_key(Map.get(encoded_record, @input_attribute)) do
       {:ok, result} ->
         {:ok,
@@ -50,9 +55,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.SwissSpeciesStrategy do
          |> Strategy.update_encoded_record(encoded_record, @output_attributes)}
 
       {:error, %Ash.Error.Query.NotFound{}} ->
-        Logger.warning(
-          "[swiss_species_strategy] no matching encoded_record found for taxon_id: #{encoded_record.tax_taxon_id}"
-        )
+        Logger.warning("[swiss_species] no matching encoded_record found for taxon_id: #{encoded_record.tax_taxon_id}")
 
         {:ok, encoded_record}
 
@@ -64,7 +67,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.SwissSpeciesStrategy do
   @spec handle_error(String.t(), map()) :: :ok
   defp handle_error(encoded_record_id, error) do
     Logger.warning(
-      "Error while encoding the encoded_record #{encoded_record_id} with the swiss species catalog: #{inspect(error)}"
+      "[swiss_species] Error while encoding the encoded_record #{encoded_record_id} with the swiss species catalog: #{inspect(error)}"
     )
   end
 end

--- a/lib/data_aggregator/records/encoding/strategies/taxonomy/swiss_species_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/taxonomy/swiss_species_strategy.ex
@@ -23,44 +23,46 @@ defmodule DataAggregator.Records.Encoding.Strategy.SwissSpeciesStrategy do
     lookup the swiss species registry and return the encoded record
   """
   @spec apply_strategy(EncodedRecord.t()) :: EncodingResult.t()
-  def apply_strategy(record) do
-    case process_record(record) do
-      {:ok, record} ->
-        {:ok, record}
+  def apply_strategy(encoded_record) do
+    case process_encoded_record(encoded_record) do
+      {:ok, encoded_record} ->
+        {:ok, encoded_record}
 
-      {:error, error} ->
-        handle_error(record.id, error)
+      {:error, error, encoded_record} ->
+        handle_error(encoded_record.id, error)
 
-        {:error, error}
+        {:error, error, encoded_record}
     end
   rescue
     error ->
-      handle_error(record.id, error)
+      handle_error(encoded_record.id, error)
 
-      {:error, error}
+      {:error, error, encoded_record}
   end
 
-  @spec process_record(EncodedRecord.t()) :: EncodingResult.t()
-  defp process_record(record) do
-    case SwissSpecies.get_by_usage_key(Map.get(record, @input_attribute)) do
+  @spec process_encoded_record(EncodedRecord.t()) :: EncodingResult.t()
+  defp process_encoded_record(encoded_record) do
+    case SwissSpecies.get_by_usage_key(Map.get(encoded_record, @input_attribute)) do
       {:ok, result} ->
         {:ok,
          result
          |> Map.from_struct()
-         |> Strategy.update_encoded_record(record, @output_attributes)}
+         |> Strategy.update_encoded_record(encoded_record, @output_attributes)}
 
       {:error, %Ash.Error.Query.NotFound{}} ->
-        Logger.warning("no matching record found for taxon_id: #{record.tax_taxon_id}")
+        Logger.warning("no matching encoded_record found for taxon_id: #{encoded_record.tax_taxon_id}")
 
-        {:ok, record}
+        {:ok, encoded_record}
 
       {:error, error} ->
-        {:error, error}
+        {:error, error, encoded_record}
     end
   end
 
   @spec handle_error(String.t(), map()) :: :ok
-  defp handle_error(record_id, error) do
-    Logger.warning("Error while encoding the record #{record_id} with the swiss species catalog: #{inspect(error)}")
+  defp handle_error(encoded_record_id, error) do
+    Logger.warning(
+      "Error while encoding the encoded_record #{encoded_record_id} with the swiss species catalog: #{inspect(error)}"
+    )
   end
 end

--- a/lib/data_aggregator/records/encoding/strategies/taxonomy/swiss_species_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/taxonomy/swiss_species_strategy.ex
@@ -50,7 +50,9 @@ defmodule DataAggregator.Records.Encoding.Strategy.SwissSpeciesStrategy do
          |> Strategy.update_encoded_record(encoded_record, @output_attributes)}
 
       {:error, %Ash.Error.Query.NotFound{}} ->
-        Logger.warning("no matching encoded_record found for taxon_id: #{encoded_record.tax_taxon_id}")
+        Logger.warning(
+          "[swiss_species_strategy] no matching encoded_record found for taxon_id: #{encoded_record.tax_taxon_id}"
+        )
 
         {:ok, encoded_record}
 

--- a/lib/data_aggregator/records/encoding/types/encoding_action_result.ex
+++ b/lib/data_aggregator/records/encoding/types/encoding_action_result.ex
@@ -4,5 +4,5 @@ defmodule DataAggregator.Records.Encoding.EncodingActionResult do
   """
   alias DataAggregator.Records.Record
 
-  @type t :: {:ok, Record.t()} | {:error, any()}
+  @type t :: {:ok, Record.t()} | {:error, any(), Record.t()}
 end

--- a/lib/data_aggregator/records/encoding/types/encoding_result.ex
+++ b/lib/data_aggregator/records/encoding/types/encoding_result.ex
@@ -3,6 +3,7 @@ defmodule DataAggregator.Records.Encoding.EncodingResult do
     This module is represents the result of an encoding process
   """
   alias DataAggregator.Records.EncodedRecord
+  alias DataAggregator.Records.Record
 
-  @type t :: {:ok, EncodedRecord.t()} | {:error, any()}
+  @type t :: {:ok, EncodedRecord.t()} | {:error, any(), EncodedRecord.t() | Record.t()}
 end

--- a/lib/data_aggregator/records/encoding/types/encoding_result.ex
+++ b/lib/data_aggregator/records/encoding/types/encoding_result.ex
@@ -3,7 +3,6 @@ defmodule DataAggregator.Records.Encoding.EncodingResult do
     This module is represents the result of an encoding process
   """
   alias DataAggregator.Records.EncodedRecord
-  alias DataAggregator.Records.Record
 
-  @type t :: {:ok, EncodedRecord.t()} | {:error, any(), EncodedRecord.t() | Record.t()}
+  @type t :: {:ok, EncodedRecord.t()} | {:error, any(), EncodedRecord.t()}
 end

--- a/lib/data_aggregator/records/encoding/workers/encoder.ex
+++ b/lib/data_aggregator/records/encoding/workers/encoder.ex
@@ -44,8 +44,8 @@ defmodule DataAggregator.Records.Record.Workers.Encoder do
         {:ok, record},
         fn catalog, {:ok, acc} ->
           case Record.encode(acc, catalog) do
-            {:ok, encoded_record} ->
-              {:cont, {:ok, encoded_record}}
+            {:ok, record} ->
+              {:cont, {:ok, record}}
 
             {:error, error} ->
               {:halt, {:error, error}}

--- a/lib/data_aggregator/records/record/actions/encode_record.ex
+++ b/lib/data_aggregator/records/record/actions/encode_record.ex
@@ -37,7 +37,7 @@ defmodule DataAggregator.Records.Encoding.Actions.EncodeRecord do
 
       {:error, error, record} ->
         Logger.warning(
-          "Encoding for record #{record.id} with catalog: #{to_string(catalog)} failed, due to: #{inspect(error)}"
+          "[#{catalog}] Encoding for record #{record.id} with catalog: #{to_string(catalog)} failed, due to: #{inspect(error)}"
         )
 
         {:ok, record}

--- a/lib/data_aggregator/records/record/actions/encode_record.ex
+++ b/lib/data_aggregator/records/record/actions/encode_record.ex
@@ -1,6 +1,6 @@
 defmodule DataAggregator.Records.Encoding.Actions.EncodeRecord do
   @moduledoc """
-  Encode Record with passed catalog
+  Encode Record with passed catalog. Returns the record itself after encoding.
   """
   use Ash.Resource.Actions.Implementation
 
@@ -19,18 +19,22 @@ defmodule DataAggregator.Records.Encoding.Actions.EncodeRecord do
           any()
         ) :: EncodingActionResult.t()
   def run(input, _opts, _context) do
+    # track if it was failed and set accordingly afterwards
+    previous_state = input.arguments.record.state
     record = set_encoding_state!(input.arguments.record)
     catalog = input.arguments.catalog
 
     Logger.debug("Encoding record with catalog: #{to_string(catalog)} started")
 
-    # process the encoding with the passed catalog
+    # Process the encoding with the passed catalog
+    # Strategy.encode/2 returns an EncodingResult.t() (encoded_record) and
+    # update_state/1 returns an EncodingActionResult.t() (record)
     case record
          |> Strategy.encode(catalog)
-         |> update_state() do
+         |> update_state(previous_state) do
       {:ok, record} ->
         Logger.debug(
-          "Encoding for record #{record.id} with catalog: #{to_string(catalog)} finished with result: #{inspect(record)}"
+          "[#{catalog}] Encoding for record #{record.id} with catalog: #{to_string(catalog)} finished with result: #{inspect(record)}"
         )
 
         {:ok, record}
@@ -45,16 +49,20 @@ defmodule DataAggregator.Records.Encoding.Actions.EncodeRecord do
   end
 
   # set the state the processed record to `:encoded` or `:failed` and return it
-  @spec update_state(EncodingResult.t()) :: EncodingActionResult.t()
-  defp update_state(encoding_result) do
+  # keep track if a previous state was failed. In that case, set the state to `:failed`
+  # even if the encoding was successful
+  @spec update_state(EncodingResult.t(), atom()) :: EncodingActionResult.t()
+  defp update_state(encoding_result, previous_state) do
     case encoding_result do
       {:ok, encoded_record} ->
         record = get_record(encoded_record)
 
-        {:ok, set_encoded_state!(record)}
+        record =
+          if previous_state === :failed,
+            do: set_failed_state!(record),
+            else: set_encoded_state!(record)
 
-      {:error, error, %Record{} = record} ->
-        {:error, error, set_failed_state!(record)}
+        {:ok, record}
 
       {:error, error, encoded_record} ->
         record = get_record(encoded_record)

--- a/lib/data_aggregator/records/record/actions/encode_record.ex
+++ b/lib/data_aggregator/records/record/actions/encode_record.ex
@@ -19,7 +19,7 @@ defmodule DataAggregator.Records.Encoding.Actions.EncodeRecord do
           any()
         ) :: EncodingActionResult.t()
   def run(input, _opts, _context) do
-    record = set_encoding_state(input.arguments.record)
+    record = set_encoding_state!(input.arguments.record)
     catalog = input.arguments.catalog
 
     Logger.debug("Encoding record with catalog: #{to_string(catalog)} started")
@@ -28,31 +28,38 @@ defmodule DataAggregator.Records.Encoding.Actions.EncodeRecord do
     case record
          |> Strategy.encode(catalog)
          |> update_state() do
-      {:ok, encoded_record} ->
+      {:ok, record} ->
         Logger.debug(
-          "Encoding for record #{record.id} with catalog: #{to_string(catalog)} finished with result: #{inspect(encoded_record)}"
+          "Encoding for record #{record.id} with catalog: #{to_string(catalog)} finished with result: #{inspect(record)}"
         )
 
-        {:ok, encoded_record}
+        {:ok, record}
 
-      {:error, error} ->
+      {:error, error, record} ->
         Logger.warning(
           "Encoding for record #{record.id} with catalog: #{to_string(catalog)} failed, due to: #{inspect(error)}"
         )
 
-        set_failed_state!(record)
-
-        {:error, error}
+        {:ok, record}
     end
   end
 
   # set the state the processed record to `:encoded` or `:failed` and return it
   @spec update_state(EncodingResult.t()) :: EncodingActionResult.t()
   defp update_state(encoding_result) do
-    with {:ok, encoded_record} <- encoding_result do
-      record = get_record(encoded_record)
+    case encoding_result do
+      {:ok, encoded_record} ->
+        record = get_record(encoded_record)
 
-      {:ok, set_encoded_state(record)}
+        {:ok, set_encoded_state!(record)}
+
+      {:error, error, %Record{} = record} ->
+        {:error, error, set_failed_state!(record)}
+
+      {:error, error, encoded_record} ->
+        record = get_record(encoded_record)
+
+        {:error, error, set_failed_state!(record)}
     end
   end
 
@@ -64,14 +71,14 @@ defmodule DataAggregator.Records.Encoding.Actions.EncodeRecord do
   end
 
   # update state of records to `:encoding`
-  @spec set_encoding_state(Record.t()) :: Record.t()
-  defp set_encoding_state(record) do
+  @spec set_encoding_state!(Record.t()) :: Record.t()
+  defp set_encoding_state!(record) do
     Record.set_encoding!(record)
   end
 
   # update state of record to `:encoded`
-  @spec set_encoded_state(Record.t()) :: Record.t()
-  defp set_encoded_state(record) do
+  @spec set_encoded_state!(Record.t()) :: Record.t()
+  defp set_encoded_state!(record) do
     Record.set_encoded!(record)
   end
 

--- a/lib/data_aggregator/records/types/activity.ex
+++ b/lib/data_aggregator/records/types/activity.ex
@@ -5,7 +5,7 @@ defmodule DataAggregator.Records.Activity do
 
   alias __MODULE__
 
-  defstruct [:name, :actor, :date_time, :content]
+  defstruct [:name, :actor, :date_time, :content, :source]
 
   @type t :: %Activity{}
 end

--- a/lib/data_aggregator_web/live/collection_live/import/index.ex
+++ b/lib/data_aggregator_web/live/collection_live/import/index.ex
@@ -264,7 +264,13 @@ defmodule DataAggregatorWeb.CollectionLive.Import.Index do
                   </div>
                 </div>
                 <div :if={@selected_import.rows_invalid_count in [0, nil]} class="text-italic">
-                  <%= ~t"No errors found"m %>
+                  <%= if @selected_import.state == :failed do %>
+                    <div class="text-error">
+                      <%= ~t"An unknown error occurred"m %>
+                    </div>
+                  <% else %>
+                    <%= ~t"No errors found"m %>
+                  <% end %>
                 </div>
               </div>
             </:item>

--- a/lib/data_aggregator_web/live/collection_live/record/activity_feed.ex
+++ b/lib/data_aggregator_web/live/collection_live/record/activity_feed.ex
@@ -346,6 +346,7 @@ defmodule DataAggregatorWeb.CollectionLive.Record.ActivityFeed do
 
     sorted_activities =
       (record_versions ++ encoded_record_versions)
+      |> Enum.filter(&(&1.changes != %{}))
       |> activites_from_versions()
       |> sort_activities()
 

--- a/lib/data_aggregator_web/live/collection_live/record/activity_feed.ex
+++ b/lib/data_aggregator_web/live/collection_live/record/activity_feed.ex
@@ -5,6 +5,7 @@ defmodule DataAggregatorWeb.CollectionLive.Record.ActivityFeed do
   alias DataAggregator.Records.Activity
   alias DataAggregator.Records.EncodedRecord
   alias DataAggregator.Records.Record
+  alias DataAggregator.Taxonomy.Catalog
 
   require Ash.Query
 
@@ -29,23 +30,28 @@ defmodule DataAggregatorWeb.CollectionLive.Record.ActivityFeed do
 
   defp activity_feed_element(%{activity: activity} = assigns) when activity.name in [:import, :update] do
     ~H"""
-    <div class="grid w-full grid-cols-9 gap-y-2">
+    <div class="grid w-full grid-cols-9 gap-y-4">
       <div class="bg-base-100 size-6 relative flex items-center justify-center">
         <div class="bg-base-100">
           <.activity_icon activity={@activity} />
         </div>
       </div>
-      <div class="text-sm/5 col-span-6 py-0.5 text-gray-500">
-        <span class="font-medium text-gray-600"><%= @activity.actor %></span>
+      <div class="text-sm/5 text-base-content/60 col-span-6 py-0.5">
+        <span class="text-base-content font-medium"><%= @activity.actor %></span>
         - <.activity_text activity={@activity} />
       </div>
       <div class="col-span-2 text-right">
-        <time datetime={@activity.date_time} class="text-xs/5 py-0.5 text-gray-500">
+        <time datetime={@activity.date_time} class="text-xs/5 text-base-content/60 py-0.5">
           <%= format_datetime(@activity.date_time, format: :short) %>
         </time>
       </div>
-      <div class="ring-gray-100/30 col-start-2 col-end-10 rounded-md pt-3 pr-2 pb-2 pl-3 ring-1 hover:ring-2">
-        <.changed_value :for={change <- map_to_string(@activity.content)} value={change} />
+      <div class="indicator col-start-2 col-end-10 w-auto">
+        <span class="indicator-item end-2 badge badge-primary badge-sm translate-x-0">
+          <%= @activity.source %>
+        </span>
+        <div class="ring-base-content/20 w-full rounded-md pt-5 pr-2 pb-4 pl-4 ring-1">
+          <.changed_value :for={change <- map_to_string(@activity.content)} value={change} />
+        </div>
       </div>
     </div>
     """
@@ -60,12 +66,12 @@ defmodule DataAggregatorWeb.CollectionLive.Record.ActivityFeed do
           <.activity_icon activity={@activity} />
         </div>
       </div>
-      <div class="text-sm/5 col-span-6 py-0.5 text-gray-500">
-        <span class="font-medium text-gray-600"><%= @activity.actor %></span>
+      <div class="text-sm/5 text-base-content/60 col-span-6 py-0.5">
+        <span class="text-base-content font-medium"><%= @activity.actor %></span>
         - <.activity_text activity={@activity} />
       </div>
       <div class="col-span-2 text-right">
-        <time datetime={@activity.date_time} class="text-xs/5 py-0.5 text-gray-500">
+        <time datetime={@activity.date_time} class="text-xs/5 text-base-content/60 py-0.5">
           <%= format_datetime(@activity.date_time, format: :short) %>
         </time>
       </div>
@@ -76,7 +82,17 @@ defmodule DataAggregatorWeb.CollectionLive.Record.ActivityFeed do
   # this is just the fallback for unwanted activities, which we do not want to render
   defp activity_feed_element(assigns) do
     ~H"""
-    <span>unknown change: <%= @activity.name %></span>
+    <div class="grid w-full grid-cols-9 gap-y-4">
+      <div class="bg-base-100 size-6 relative flex items-center justify-center">
+        <div class="bg-base-100">
+          <.activity_icon />
+        </div>
+      </div>
+      <div class="text-sm/5 text-base-content/60 col-span-6 py-0.5">
+        <span class="text-base-content font-medium"><%= @activity.actor %></span>
+        - <span>unknown change: <%= @activity.name %></span>
+      </div>
+    </div>
     """
   end
 
@@ -166,11 +182,19 @@ defmodule DataAggregatorWeb.CollectionLive.Record.ActivityFeed do
     end
   end
 
-  defp activity_icon(assigns) do
+  defp activity_icon(%{activity: _activity} = assigns) do
     ~H"""
     <span>
       <%= @activity.name %> - <%= inspect(@activity.content) %>
     </span>
+    """
+  end
+
+  defp activity_icon(assigns) do
+    ~H"""
+    <.badge class="tooltip tooltip-right" data-tip={~t"Unknown activity"m} color="gray">
+      <.icon name="hero-question-mark-circle-solid" class="size-5 shrink-0" />
+    </.badge>
     """
   end
 
@@ -346,11 +370,16 @@ defmodule DataAggregatorWeb.CollectionLive.Record.ActivityFeed do
 
     sorted_activities =
       (record_versions ++ encoded_record_versions)
-      |> Enum.filter(&(&1.changes != %{}))
+      |> Enum.filter(&filter_version/1)
       |> activites_from_versions()
       |> sort_activities()
 
     assign(assigns, :activities, sorted_activities)
+  end
+
+  defp filter_version(version) do
+    version.version_action_name not in [:set_encoding_failed, :set_encoded] or
+      version.changes != %{}
   end
 
   defp published?(activity) do
@@ -396,8 +425,52 @@ defmodule DataAggregatorWeb.CollectionLive.Record.ActivityFeed do
       name: version.version_action_name,
       actor: "Owner",
       date_time: version.version_inserted_at,
-      content: version.changes
+      content: version.changes,
+      source: version_source(version)
     }
+  end
+
+  defp version_source(%{version_action_name: :update_fast_track_status}), do: ~t"Publication"
+  defp version_source(%{version_action_name: :update_approval_status}), do: ~t"Approval"
+  defp version_source(%{version_action_name: :import}), do: ~t"Import"
+
+  defp version_source(%{version_action_name: :update} = version), do: version_source_from_catalog(version.changes)
+
+  defp version_source(_), do: nil
+
+  defp version_source_from_catalog(%{} = changes) when changes == %{}, do: ~t"Unknown"
+
+  defp version_source_from_catalog(%{} = changes) do
+    keys =
+      changes
+      |> Map.keys()
+      |> Enum.map(&String.to_existing_atom/1)
+
+    catalogs = Catalog.get_catalogs()
+
+    catalog_name =
+      Enum.reduce_while(catalogs, nil, fn catalog, _ ->
+        catalog_output_dwc_attributes = Catalog.get_output_dwc_attributes(catalog)
+
+        if Enum.all?(keys, &Enum.member?(catalog_output_dwc_attributes, &1)) do
+          {:halt, catalog}
+        else
+          {:cont, nil}
+        end
+      end)
+
+    translate_catalog_name(catalog_name)
+  end
+
+  defp translate_catalog_name(catalog) do
+    case catalog do
+      :gbif_taxonomy -> ~t"GBIF Taxonomy"
+      :gbif_iucn_redlist -> ~t"GBIF IUCN Redlist"
+      :swiss_species -> ~t"Swiss Species"
+      :geo_reverse -> ~t"Geo Reverse"
+      :geo_forward -> ~t"Geo Forward"
+      _ -> ~t"Unknown"
+    end
   end
 
   defp record_versions(assigns) do
@@ -437,7 +510,7 @@ defmodule DataAggregatorWeb.CollectionLive.Record.ActivityFeed do
     map
     |> stringify_values()
     |> Map.to_list()
-    |> filter_nil_values()
+    |> map_nil_values()
     |> Enum.map(fn {k, v} -> {k, value_to_list(v)} end)
   end
 
@@ -445,8 +518,14 @@ defmodule DataAggregatorWeb.CollectionLive.Record.ActivityFeed do
     inspect(map)
   end
 
-  defp filter_nil_values(list) do
-    Enum.filter(list, fn {_, v} -> v != nil end)
+  defp map_nil_values(list) do
+    Enum.map(list, fn {k, v} ->
+      if v == nil do
+        {k, "-"}
+      else
+        {k, v}
+      end
+    end)
   end
 
   defp value_to_list(value) when is_map(value) do

--- a/lib/data_aggregator_web/live/collection_live/record/index.ex
+++ b/lib/data_aggregator_web/live/collection_live/record/index.ex
@@ -394,6 +394,12 @@ defmodule DataAggregatorWeb.CollectionLive.Record.Index do
               phx-value-tab="changes"
               active={@record_tab == "changes"}
             />
+            <.secondary_navigation_item
+              label={~t"Encodings"m}
+              on_click="record:set_tab"
+              phx-value-tab="encodings"
+              active={@record_tab == "encodings"}
+            />
           </.secondary_navigation>
           <div :if={@record_tab == "data"} class="contents">
             <%= for category <- @attrs_in_categories do %>
@@ -425,36 +431,36 @@ defmodule DataAggregatorWeb.CollectionLive.Record.Index do
                 </div>
               </details>
             <% end %>
-            <details class="collapse collapse-arrow border-black-white/10 rounded-none border-b px-2 open:bg-base-300/30 lg:pl-4">
-              <summary class="collapse-title">
-                <%= ~t"Record encodings"m %>
-              </summary>
-              <div class="collapse-content">
-                <p class="text-base-content/60 text-sm/6 line-clamp-2 max-w-4xl">
-                  <%= ~t"Results by catalog"m %>
-                </p>
-
-                <.table
-                  opts={[
-                    container_attrs: [class: "no-scrollbar overflow-x-auto -mx-6 lg:-mx-8 pb-4"]
-                  ]}
-                  id="encoding_result_table"
-                  items={@record_encoding_results}
-                >
-                  <:col :let={result} label={~t"Catalog"} class="font-semibold">
-                    <%= result.catalog %>
-                  </:col>
-                  <:col :let={result} label={~t"State"} class="text-center">
-                    <.encoding_state_badge reason={result.message} state={result.state} />
-                  </:col>
-                  <:col :let={result} label={~t"Created"} class="text-right">
-                    <%= format_datetime(result.inserted_at, format: :short) %>
-                  </:col>
-                </.table>
-              </div>
-            </details>
           </div>
           <.activity_feed :if={@record_tab == "changes"} record={@selected_record} />
+          <div :if={@record_tab == "encodings"} class="px-6 pt-4 lg:px-8">
+            <h2 class="pb-2">
+              <%= ~t"Record encodings"m %>
+            </h2>
+            <div class="">
+              <p class="text-base-content/60 text-sm/6 line-clamp-2 max-w-4xl">
+                <%= ~t"Results by catalog"m %>
+              </p>
+
+              <.table
+                opts={[
+                  container_attrs: [class: "no-scrollbar overflow-x-auto -mx-6 lg:-mx-8 pb-4"]
+                ]}
+                id="encoding_result_table"
+                items={@record_encoding_results}
+              >
+                <:col :let={result} label={~t"Catalog"} class="font-semibold">
+                  <%= result.catalog %>
+                </:col>
+                <:col :let={result} label={~t"State"} class="text-center">
+                  <.encoding_state_badge reason={result.message} state={result.state} />
+                </:col>
+                <:col :let={result} label={~t"Created"} class="text-right">
+                  <%= format_datetime(result.inserted_at, format: :short) %>
+                </:col>
+              </.table>
+            </div>
+          </div>
         </.slideover>
       </:secondary>
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -320,7 +320,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "All records"
 msgstr "Alle Einträge"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:723
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:729
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Collection Records"
@@ -339,37 +339,37 @@ msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Description"
 msgstr "Beschreibung"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:444
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:452
 #: lib/data_aggregator_web/live/record_live/index.ex:151
 #, elixir-autogen, elixir-format
 msgid "Catalog"
 msgstr "Katalog"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:450
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:458
 #: lib/data_aggregator_web/live/record_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgid "Created"
 msgstr "Erstellt"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:421
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:427
 #: lib/data_aggregator_web/live/record_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Encoded"
 msgstr "Enkodierung"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:418
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:424
 #: lib/data_aggregator_web/live/record_live/index.ex:127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported"
 msgstr "Importe"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:415
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:421
 #: lib/data_aggregator_web/live/record_live/index.ex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Name"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:447
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:455
 #: lib/data_aggregator_web/live/record_live/index.ex:154
 #, elixir-autogen, elixir-format
 msgid "State"
@@ -459,14 +459,14 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Encoding"
 msgstr "Enkodierung"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:430
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:507
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:438
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:513
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record encodings"
 msgstr "Enkodierungen"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:434
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:442
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Results by catalog"
@@ -592,19 +592,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "New Import"
 msgstr "Neuer Import"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:768
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:774
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Get started by importing a new dataset"
 msgstr "Beginne, indem Du einen neuen Datensatz importierst"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:769
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:775
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Import"
 msgstr "Import"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:767
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:773
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "No records"
@@ -1061,9 +1061,9 @@ msgid "Mapping is invalid"
 msgstr "Zuordnung ist ungültig"
 
 #: lib/data_aggregator_web/live/collection_live/record/index.ex:365
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:524
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:534
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:544
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:530
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:540
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:550
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Are you sure?"
@@ -1075,31 +1075,31 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:586
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record deleted successfully"
 msgstr "Eintrag erfolgreich gelöscht"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:510
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:516
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record encoding results"
 msgstr "Enkodierungsergebnisse"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:516
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:522
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record images"
 msgstr "Bilder"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:513
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:519
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record imports"
 msgstr "Importeinträge"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:504
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:510
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "This will also delete the following associations:"
@@ -1583,19 +1583,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Record was changed after publishing it and has to be republished"
 msgstr "Der Eintrag wurde geändert nachdem er veröffentlicht wurde und muss erneut publiziert werden"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:525
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:531
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to encode this collection"
 msgstr "Du bist dabei diese Sammlung zu enkodieren"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:535
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:541
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to publish this collection directly to the Gbif.ch Portal"
 msgstr "Du bist dabei diese Sammlung direkt ins Gbif.ch Portal zu publizieren"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:545
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:551
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to publish this collection to Infospecies for approval"
@@ -1667,154 +1667,154 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Publication failed. Process should be started again"
 msgstr "Veröffentlichung fehlgeschlagen. Der Prozess sollte erneut gestartet werden"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:180
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "A data import was updating the record"
 msgstr "Ein Datenimport hat den Eintrag aktualisiert"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:85
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Dataset imported"
 msgstr "Dataset wurde importiert"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:93
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:109
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoded data updated"
 msgstr "Enkodierte Daten wurden aktualisiert"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:101
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:117
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoding Successful"
 msgstr "Enkodierung erfolgreich"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:109
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:125
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoding failed"
 msgstr "Enkodierung fehlgeschlagen"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:210
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:254
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:278
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:244
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:268
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "In Publication"
 msgstr "Veröffentlichung läuft"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:274
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:298
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Not yet Published"
 msgstr "Noch nicht veröffentlicht"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:145
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publication failed"
 msgstr "Veröffentlichung fehlgeschlagen"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:224
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:248
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Published"
 msgstr "Veröffentlicht"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:258
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publishing"
 msgstr "In Veröffentlichung"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:127
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:159
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:143
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:175
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publishing in progress"
 msgstr "In Veröffentlichung"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:152
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:168
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record data changed"
 msgstr "Eintrag wurde geändert"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:136
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:152
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is now in the publication pipeline"
 msgstr "Der Eintrag ist jetzt in der Veröffentlichung"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:264
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:288
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Stale"
 msgstr "Veraltet"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:199
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:223
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Successful"
 msgstr "Erfolgreich"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:120
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:136
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Successful published"
 msgstr "Erfolgreich veröffentlicht"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:188
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:212
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record was updated by encoding"
 msgstr "Der Eintrag wurde durch Enkodierung aktualisiert"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:271
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:295
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is"
 msgstr "Einträge"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:231
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:241
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:255
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:265
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is currently"
 msgstr "der Eintrag ist zur Zeit"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:251
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:275
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record publication"
 msgstr "Die Veröffentlichung ist"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:221
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:245
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record was successful"
 msgstr "Der Eintrag wurde erfolgreich veröffentlicht"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:261
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:285
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The publication is now"
 msgstr "Die Veröffentlichung ist jetzt"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:207
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:231
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record encoding has"
 msgstr "Das Enkodieren ist"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:196
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:220
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record encoding was"
@@ -2033,13 +2033,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.FilterComponent"
 msgid "entries"
 msgstr "Einträge"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:489
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:495
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:496
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:502
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "records"
@@ -2171,13 +2171,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Index"
 msgid "Publications and Approvals"
 msgstr "Veröffentlichungen und Genehmigungen"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:296
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:320
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Approval status was updated"
 msgstr "Genehmigungsstatus wurde aktualisiert"
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:303
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:327
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publication status was updated"
@@ -2391,73 +2391,73 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Subscriptions"
 msgid "The publication has been completed"
 msgstr "Die Veröffentlichung wurde abgeschlossen"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:647
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:653
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "A publication for this collection is already in process"
 msgstr "Eine Veröffentlichung für diese Sammlung ist bereits im Gange"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:667
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:673
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "An approval for this collection is already in process"
 msgstr "Eine Genehmigung für diese Sammlung ist bereits im Gange"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:627
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:633
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "An encoding for this collection is already in process"
 msgstr "Eine Enkodierung für diese Sammlung ist bereits im Gange"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:663
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:669
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Approval started in background"
 msgstr "Genehmigung im Hintergrund gestartet"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:624
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:630
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Encoding started in background"
 msgstr "Enkodierung im Hintergrund gestartet"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:779
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:785
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "No records found"
 msgstr "Keine Einträge gefunden"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:643
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:649
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Publication started in background"
 msgstr "Veröffentlichung im Hintergrund gestartet"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:780
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:786
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Try with a different filter"
 msgstr "Versuche es mit einem anderen Filter"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:546
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:552
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, approve"
 msgstr "Ja, genehmigen"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:503
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:509
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, delete record"
 msgstr "Ja, Eintrag löschen"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:526
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:532
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, encode"
 msgstr "Ja, enkodieren"
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:536
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:542
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, publish"
@@ -2790,3 +2790,61 @@ msgstr "Löschen"
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "An unknown error occurred"
 msgstr "Ein unbekannter Fehler ist aufgetreten"
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:434
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Approval"
+msgstr "Genehmigung"
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:468
+#, elixir-autogen, elixir-format
+msgid "GBIF IUCN Redlist"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:467
+#, elixir-autogen, elixir-format, fuzzy
+msgid "GBIF Taxonomy"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:471
+#, elixir-autogen, elixir-format
+msgid "Geo Forward"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:470
+#, elixir-autogen, elixir-format
+msgid "Geo Reverse"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:435
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Import"
+msgstr "Import"
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:433
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Publication"
+msgstr "Veröffentlichung"
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:469
+#, elixir-autogen, elixir-format
+msgid "Swiss Species"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:441
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:472
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:195
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
+msgid "Unknown activity"
+msgstr "Unbekannte Aktivität"
+
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:398
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
+msgid "Encodings"
+msgstr "Enkodierungen"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -308,7 +308,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Components.Header"
 msgid "Import dataset"
 msgstr "Datensatz importieren"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:511
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:517
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Collection Imports"
@@ -493,7 +493,7 @@ msgstr "Datei"
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:123
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:198
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:328
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:334
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapping is invalid"
@@ -520,7 +520,7 @@ msgid "Size"
 msgstr "Größe"
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:104
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:287
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:293
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Started at"
@@ -580,13 +580,13 @@ msgctxt "DataAggregatorWeb.Blocks.EmptyState"
 msgid "No entries"
 msgstr "Keine Einträge"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:525
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:531
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Edit Import"
 msgstr "Import bearbeiten"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:517
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:523
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "New Import"
@@ -652,26 +652,26 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Upload"
 msgid "Please provide your collection file holding your records."
 msgstr "Bitte gib deine Sammlungsdatei an, die deine Einträge enthält."
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:554
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:560
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Get started by importing a new dataset."
 msgstr "Beginne, indem Du einen neuen Datensatz importierst"
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:169
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:555
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:561
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import"
 msgstr "Import"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:535
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import Summary"
 msgstr "Importzusammenfassung"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:553
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:559
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "No imports"
@@ -756,21 +756,21 @@ msgid "close"
 msgstr "schließen"
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:151
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:356
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:438
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:362
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:444
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Are you sure?"
 msgstr "Bist Du sicher?"
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:150
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:361
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:367
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:464
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:470
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import deleted successfully"
@@ -895,7 +895,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.FormComponent"
 msgid "You are not allowed to process an import twice. Please start again by uploading a new import dataset."
 msgstr "Wir dürfen einen Import nicht zweimal verarbeiten. Bitte fahre fort, indem Du einen neuen Importdatensatz hochlädst."
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:323
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:329
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Column"
@@ -908,7 +908,7 @@ msgid "Created at"
 msgstr "Erstellt am"
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:141
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:318
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:324
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Edit"
@@ -920,19 +920,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import status and mapping details."
 msgstr "Importstatus und Zuordnungsdetails."
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:272
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:278
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Imported"
 msgstr "Importiert"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:331
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:337
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapped to"
 msgstr "Gemappt auf"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:301
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:307
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapping"
@@ -970,13 +970,13 @@ msgid "invalid rows:"
 msgstr "ungültige Zeilen:"
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:233
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:282
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:288
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "rows"
 msgstr "Zeilen"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:337
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:343
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Unmapped columns"
@@ -2074,22 +2074,22 @@ msgstr "Standort"
 msgid "Download error log"
 msgstr "Fehlerprotokoll runterladen"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:397
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:403
 #, elixir-autogen, elixir-format
 msgid "Error message"
 msgstr "Fehlermeldung"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:391
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:397
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Field"
 msgstr "Feld"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:372
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:378
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import Errors"
 msgstr "Import Fehler"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:406
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:412
 #, elixir-autogen, elixir-format
 msgid "Only the first 100 rows will be shown. Download the file to have the complete log"
 msgstr "Nur die ersten 100 Zeilen werden angezeigt. Für eine komplette Liste, lade das Fehlerlog runter"
@@ -2099,7 +2099,7 @@ msgstr "Nur die ersten 100 Zeilen werden angezeigt. Für eine komplette Liste, l
 msgid "The selected mapping used by a previous import on this collection is not compatible with the current import file. Please create a new mapping or upload a compatible file."
 msgstr "Das ausgewählte Mapping, das für einen früheren Import verwendet wurde, ist nicht mit dieser Datei kompatibel. Bitte erstelle ein neues Mapping oder lade eine kompatible Datei hoch."
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:394
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:400
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr "Wert"
@@ -2110,7 +2110,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Error Log"
 msgstr "Fehlerprotokoll"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:267
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:272
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "No errors found"
@@ -2213,12 +2213,12 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Components"
 msgid "Publication to the Gbif Switzerland Portal"
 msgstr "Veröffentlichung in das Gbif Switzerland Portal"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:453
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:459
 #, elixir-autogen, elixir-format
 msgid "An import for this collection is already in process"
 msgstr "Ein Import für diese Sammlung ist bereits im Gange"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:450
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:456
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import started in background"
 msgstr "Import im Hintergrund gestartet"
@@ -2331,7 +2331,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Summary"
 msgid "An import for this collection is already in process"
 msgstr "Ein Import für diese Sammlung ist bereits im Gange"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:439
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:445
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Yes, delete import"
@@ -2749,13 +2749,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:385
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:391
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Catalog Number"
 msgstr "Katalognummer"
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:388
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:394
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Scientific Name"
@@ -2784,3 +2784,9 @@ msgstr "Lädt hoch..."
 msgctxt "DataAggregatorWeb.CollectionLive.Components"
 msgid "Deleting"
 msgstr "Löschen"
+
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:269
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
+msgid "An unknown error occurred"
+msgstr "Ein unbekannter Fehler ist aufgetreten"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -308,7 +308,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Components.Header"
 msgid "Import dataset"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:511
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:517
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Collection Imports"
@@ -493,7 +493,7 @@ msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:123
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:198
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:328
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:334
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapping is invalid"
@@ -520,7 +520,7 @@ msgid "Size"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:104
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:287
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:293
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Started at"
@@ -580,13 +580,13 @@ msgctxt "DataAggregatorWeb.Blocks.EmptyState"
 msgid "No entries"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:525
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:531
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Edit Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:517
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:523
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "New Import"
@@ -652,26 +652,26 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Upload"
 msgid "Please provide your collection file holding your records."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:554
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:560
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Get started by importing a new dataset."
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:169
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:555
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:561
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:535
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:541
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import Summary"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:553
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:559
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "No imports"
@@ -756,21 +756,21 @@ msgid "close"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:151
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:356
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:438
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:362
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:444
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Are you sure?"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:150
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:361
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:367
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Delete"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:464
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:470
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import deleted successfully"
@@ -895,7 +895,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.FormComponent"
 msgid "You are not allowed to process an import twice. Please start again by uploading a new import dataset."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:323
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:329
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Column"
@@ -908,7 +908,7 @@ msgid "Created at"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:141
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:318
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:324
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Edit"
@@ -920,19 +920,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import status and mapping details."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:272
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:278
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Imported"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:331
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:337
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapped to"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:301
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:307
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapping"
@@ -970,13 +970,13 @@ msgid "invalid rows:"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:233
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:282
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:288
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "rows"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:337
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:343
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Unmapped columns"
@@ -2074,22 +2074,22 @@ msgstr ""
 msgid "Download error log"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:397
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:403
 #, elixir-autogen, elixir-format
 msgid "Error message"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:391
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:397
 #, elixir-autogen, elixir-format
 msgid "Field"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:372
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:378
 #, elixir-autogen, elixir-format
 msgid "Import Errors"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:406
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:412
 #, elixir-autogen, elixir-format
 msgid "Only the first 100 rows will be shown. Download the file to have the complete log"
 msgstr ""
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "The selected mapping used by a previous import on this collection is not compatible with the current import file. Please create a new mapping or upload a compatible file."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:394
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:400
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
@@ -2110,7 +2110,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Error Log"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:267
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:272
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "No errors found"
@@ -2213,12 +2213,12 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Components"
 msgid "Publication to the Gbif Switzerland Portal"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:453
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:459
 #, elixir-autogen, elixir-format
 msgid "An import for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:450
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:456
 #, elixir-autogen, elixir-format
 msgid "Import started in background"
 msgstr ""
@@ -2331,7 +2331,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Summary"
 msgid "An import for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:439
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:445
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Yes, delete import"
@@ -2749,13 +2749,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Publish"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:385
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:391
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Catalog Number"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:388
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:394
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Scientific Name"
@@ -2783,4 +2783,10 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Components"
 msgid "Deleting"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:269
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
+msgid "An unknown error occurred"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -320,7 +320,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "All records"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:723
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:729
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Collection Records"
@@ -339,37 +339,37 @@ msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Description"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:444
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:452
 #: lib/data_aggregator_web/live/record_live/index.ex:151
 #, elixir-autogen, elixir-format
 msgid "Catalog"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:450
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:458
 #: lib/data_aggregator_web/live/record_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgid "Created"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:421
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:427
 #: lib/data_aggregator_web/live/record_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Encoded"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:418
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:424
 #: lib/data_aggregator_web/live/record_live/index.ex:127
 #, elixir-autogen, elixir-format
 msgid "Imported"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:415
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:421
 #: lib/data_aggregator_web/live/record_live/index.ex:124
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:447
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:455
 #: lib/data_aggregator_web/live/record_live/index.ex:154
 #, elixir-autogen, elixir-format
 msgid "State"
@@ -459,14 +459,14 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Encoding"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:430
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:507
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:438
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:513
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record encodings"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:434
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:442
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Results by catalog"
@@ -592,19 +592,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "New Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:768
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:774
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Get started by importing a new dataset"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:769
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:775
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:767
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:773
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "No records"
@@ -1061,9 +1061,9 @@ msgid "Mapping is invalid"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/record/index.ex:365
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:524
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:534
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:544
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:530
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:540
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:550
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Are you sure?"
@@ -1075,31 +1075,31 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Delete"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:586
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:592
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record deleted successfully"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:510
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:516
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record encoding results"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:516
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:522
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record images"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:513
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:519
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record imports"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:504
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:510
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "This will also delete the following associations:"
@@ -1583,19 +1583,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Record was changed after publishing it and has to be republished"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:525
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:531
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to encode this collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:535
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:541
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to publish this collection directly to the Gbif.ch Portal"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:545
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:551
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to publish this collection to Infospecies for approval"
@@ -1667,154 +1667,154 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Publication failed. Process should be started again"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:180
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:204
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "A data import was updating the record"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:85
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:101
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Dataset imported"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:93
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:109
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoded data updated"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:101
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:117
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoding Successful"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:109
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:125
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoding failed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:210
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:254
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:278
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Failed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:244
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:268
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "In Publication"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:274
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:298
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Not yet Published"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:145
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:161
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publication failed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:224
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:248
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Published"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:258
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publishing"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:127
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:159
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:143
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:175
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publishing in progress"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:152
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:168
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record data changed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:136
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:152
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is now in the publication pipeline"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:264
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:288
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Stale"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:199
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:223
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Successful"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:120
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:136
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Successful published"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:188
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:212
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record was updated by encoding"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:271
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:295
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:231
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:241
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:255
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:265
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is currently"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:251
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:275
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record publication"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:221
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:245
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record was successful"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:261
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:285
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The publication is now"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:207
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:231
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record encoding has"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:196
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:220
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record encoding was"
@@ -2033,13 +2033,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.FilterComponent"
 msgid "entries"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:489
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:495
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Filters"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:496
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:502
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "records"
@@ -2171,13 +2171,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Index"
 msgid "Publications and Approvals"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:296
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:320
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Approval status was updated"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:303
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:327
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publication status was updated"
@@ -2391,73 +2391,73 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Subscriptions"
 msgid "The publication has been completed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:647
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:653
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "A publication for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:667
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:673
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "An approval for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:627
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:633
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "An encoding for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:663
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:669
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Approval started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:624
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:630
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Encoding started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:779
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:785
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "No records found"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:643
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:649
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Publication started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:780
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:786
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Try with a different filter"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:546
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:552
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, approve"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:503
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:509
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, delete record"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:526
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:532
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, encode"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:536
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:542
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, publish"
@@ -2789,4 +2789,62 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "An unknown error occurred"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:434
+#, elixir-autogen, elixir-format
+msgid "Approval"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:468
+#, elixir-autogen, elixir-format
+msgid "GBIF IUCN Redlist"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:467
+#, elixir-autogen, elixir-format
+msgid "GBIF Taxonomy"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:471
+#, elixir-autogen, elixir-format
+msgid "Geo Forward"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:470
+#, elixir-autogen, elixir-format
+msgid "Geo Reverse"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:435
+#, elixir-autogen, elixir-format
+msgid "Import"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:433
+#, elixir-autogen, elixir-format
+msgid "Publication"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:469
+#, elixir-autogen, elixir-format
+msgid "Swiss Species"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:441
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:472
+#, elixir-autogen, elixir-format
+msgid "Unknown"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:195
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
+msgid "Unknown activity"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:398
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
+msgid "Encodings"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -320,7 +320,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "All records"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:723
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:729
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Collection Records"
@@ -339,37 +339,37 @@ msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Description"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:444
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:452
 #: lib/data_aggregator_web/live/record_live/index.ex:151
 #, elixir-autogen, elixir-format
 msgid "Catalog"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:450
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:458
 #: lib/data_aggregator_web/live/record_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgid "Created"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:421
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:427
 #: lib/data_aggregator_web/live/record_live/index.ex:130
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Encoded"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:418
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:424
 #: lib/data_aggregator_web/live/record_live/index.ex:127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:415
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:421
 #: lib/data_aggregator_web/live/record_live/index.ex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Name"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:447
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:455
 #: lib/data_aggregator_web/live/record_live/index.ex:154
 #, elixir-autogen, elixir-format
 msgid "State"
@@ -459,14 +459,14 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Encoding"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:430
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:507
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:438
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:513
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record encodings"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:434
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:442
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Results by catalog"
@@ -592,19 +592,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "New Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:768
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:774
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Get started by importing a new dataset"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:769
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:775
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:767
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:773
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "No records"
@@ -1061,9 +1061,9 @@ msgid "Mapping is invalid"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/record/index.ex:365
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:524
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:534
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:544
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:530
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:540
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:550
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Are you sure?"
@@ -1075,31 +1075,31 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Delete"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:586
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record deleted successfully"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:510
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:516
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record encoding results"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:516
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:522
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record images"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:513
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:519
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record imports"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:504
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:510
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "This will also delete the following associations:"
@@ -1583,19 +1583,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Record was changed after publishing it and has to be republished"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:525
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:531
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to encode this collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:535
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:541
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to publish this collection directly to the Gbif.ch Portal"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:545
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:551
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to publish this collection to Infospecies for approval"
@@ -1667,154 +1667,154 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Publication failed. Process should be started again"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:180
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "A data import was updating the record"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:85
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Dataset imported"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:93
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:109
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoded data updated"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:101
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:117
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoding Successful"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:109
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:125
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoding failed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:210
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:254
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:278
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Failed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:244
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:268
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "In Publication"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:274
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:298
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Not yet Published"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:145
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publication failed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:224
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:248
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Published"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:258
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publishing"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:127
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:159
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:143
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:175
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publishing in progress"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:152
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:168
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record data changed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:136
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:152
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is now in the publication pipeline"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:264
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:288
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Stale"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:199
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:223
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Successful"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:120
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:136
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Successful published"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:188
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:212
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record was updated by encoding"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:271
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:295
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:231
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:241
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:255
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:265
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is currently"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:251
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:275
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record publication"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:221
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:245
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record was successful"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:261
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:285
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The publication is now"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:207
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:231
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record encoding has"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:196
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:220
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record encoding was"
@@ -2033,13 +2033,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.FilterComponent"
 msgid "entries"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:489
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:495
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Filters"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:496
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:502
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "records"
@@ -2171,13 +2171,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Index"
 msgid "Publications and Approvals"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:296
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:320
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Approval status was updated"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:303
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:327
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publication status was updated"
@@ -2391,73 +2391,73 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Subscriptions"
 msgid "The publication has been completed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:647
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:653
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "A publication for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:667
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:673
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "An approval for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:627
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:633
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "An encoding for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:663
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:669
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Approval started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:624
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:630
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Encoding started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:779
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:785
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "No records found"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:643
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:649
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Publication started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:780
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:786
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Try with a different filter"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:546
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:552
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, approve"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:503
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:509
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, delete record"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:526
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:532
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, encode"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:536
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:542
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, publish"
@@ -2789,4 +2789,62 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "An unknown error occurred"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:434
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Approval"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:468
+#, elixir-autogen, elixir-format
+msgid "GBIF IUCN Redlist"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:467
+#, elixir-autogen, elixir-format, fuzzy
+msgid "GBIF Taxonomy"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:471
+#, elixir-autogen, elixir-format
+msgid "Geo Forward"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:470
+#, elixir-autogen, elixir-format
+msgid "Geo Reverse"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:435
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Import"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:433
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Publication"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:469
+#, elixir-autogen, elixir-format
+msgid "Swiss Species"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:441
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:472
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:195
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
+msgid "Unknown activity"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:398
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
+msgid "Encodings"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -308,7 +308,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Components.Header"
 msgid "Import dataset"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:511
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:517
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Collection Imports"
@@ -493,7 +493,7 @@ msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:123
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:198
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:328
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:334
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapping is invalid"
@@ -520,7 +520,7 @@ msgid "Size"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:104
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:287
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:293
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Started at"
@@ -580,13 +580,13 @@ msgctxt "DataAggregatorWeb.Blocks.EmptyState"
 msgid "No entries"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:525
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:531
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Edit Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:517
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:523
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "New Import"
@@ -652,26 +652,26 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Upload"
 msgid "Please provide your collection file holding your records."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:554
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:560
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Get started by importing a new dataset."
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:169
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:555
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:561
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:535
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import Summary"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:553
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:559
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "No imports"
@@ -756,21 +756,21 @@ msgid "close"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:151
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:356
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:438
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:362
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:444
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Are you sure?"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:150
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:361
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:367
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Delete"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:464
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:470
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import deleted successfully"
@@ -895,7 +895,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.FormComponent"
 msgid "You are not allowed to process an import twice. Please start again by uploading a new import dataset."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:323
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:329
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Column"
@@ -908,7 +908,7 @@ msgid "Created at"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:141
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:318
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:324
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Edit"
@@ -920,19 +920,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import status and mapping details."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:272
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:278
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Imported"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:331
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:337
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapped to"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:301
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:307
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapping"
@@ -970,13 +970,13 @@ msgid "invalid rows:"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:233
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:282
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:288
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "rows"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:337
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:343
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Unmapped columns"
@@ -2074,22 +2074,22 @@ msgstr ""
 msgid "Download error log"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:397
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:403
 #, elixir-autogen, elixir-format
 msgid "Error message"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:391
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:397
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Field"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:372
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:378
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import Errors"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:406
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:412
 #, elixir-autogen, elixir-format
 msgid "Only the first 100 rows will be shown. Download the file to have the complete log"
 msgstr ""
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "The selected mapping used by a previous import on this collection is not compatible with the current import file. Please create a new mapping or upload a compatible file."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:394
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:400
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
@@ -2110,7 +2110,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Error Log"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:267
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:272
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "No errors found"
@@ -2213,12 +2213,12 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Components"
 msgid "Publication to the Gbif Switzerland Portal"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:453
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:459
 #, elixir-autogen, elixir-format
 msgid "An import for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:450
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:456
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import started in background"
 msgstr ""
@@ -2331,7 +2331,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Summary"
 msgid "An import for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:439
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:445
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Yes, delete import"
@@ -2749,13 +2749,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Publish"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:385
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:391
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Catalog Number"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:388
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:394
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Scientific Name"
@@ -2783,4 +2783,10 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Components"
 msgid "Deleting"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:269
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
+msgid "An unknown error occurred"
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -320,7 +320,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "All records"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:723
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:729
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Collection Records"
@@ -339,37 +339,37 @@ msgctxt "DataAggregatorWeb.CollectionLive.FormComponent"
 msgid "Description"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:444
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:452
 #: lib/data_aggregator_web/live/record_live/index.ex:151
 #, elixir-autogen, elixir-format
 msgid "Catalog"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:450
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:458
 #: lib/data_aggregator_web/live/record_live/index.ex:157
 #, elixir-autogen, elixir-format
 msgid "Created"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:421
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:427
 #: lib/data_aggregator_web/live/record_live/index.ex:130
 #, elixir-autogen, elixir-format
 msgid "Encoded"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:418
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:424
 #: lib/data_aggregator_web/live/record_live/index.ex:127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Imported"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:415
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:421
 #: lib/data_aggregator_web/live/record_live/index.ex:124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Name"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:447
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:455
 #: lib/data_aggregator_web/live/record_live/index.ex:154
 #, elixir-autogen, elixir-format
 msgid "State"
@@ -459,14 +459,14 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Encoding"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:430
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:507
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:438
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:513
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record encodings"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:434
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:442
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Results by catalog"
@@ -592,19 +592,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "New Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:768
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:774
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Get started by importing a new dataset"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:769
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:775
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:767
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:773
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "No records"
@@ -1061,9 +1061,9 @@ msgid "Mapping is invalid"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/record/index.ex:365
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:524
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:534
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:544
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:530
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:540
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:550
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Are you sure?"
@@ -1075,31 +1075,31 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Delete"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:586
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record deleted successfully"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:510
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:516
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record encoding results"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:516
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:522
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record images"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:513
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:519
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Record imports"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:504
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:510
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "This will also delete the following associations:"
@@ -1583,19 +1583,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Record was changed after publishing it and has to be republished"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:525
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:531
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to encode this collection"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:535
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:541
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to publish this collection directly to the Gbif.ch Portal"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:545
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:551
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "You're about to publish this collection to Infospecies for approval"
@@ -1667,154 +1667,154 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Publication failed. Process should be started again"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:180
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:204
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "A data import was updating the record"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:85
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Dataset imported"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:93
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:109
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoded data updated"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:101
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:117
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoding Successful"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:109
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:125
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Encoding failed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:210
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:254
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:278
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Failed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:244
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:268
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "In Publication"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:274
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:298
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Not yet Published"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:145
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:161
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publication failed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:224
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:248
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Published"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:258
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publishing"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:127
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:159
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:143
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:175
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publishing in progress"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:152
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:168
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record data changed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:136
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:152
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is now in the publication pipeline"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:264
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:288
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Stale"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:199
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:223
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Successful"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:120
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:136
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Successful published"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:188
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:212
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record was updated by encoding"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:271
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:295
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:231
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:241
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:255
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:265
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record is currently"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:251
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:275
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record publication"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:221
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:245
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Record was successful"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:261
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:285
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The publication is now"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:207
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:231
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record encoding has"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:196
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:220
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "The record encoding was"
@@ -2033,13 +2033,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.FilterComponent"
 msgid "entries"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:489
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:495
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Filters"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:496
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:502
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "records"
@@ -2171,13 +2171,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Index"
 msgid "Publications and Approvals"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:296
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:320
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Approval status was updated"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:303
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:327
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Publication status was updated"
@@ -2391,73 +2391,73 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Subscriptions"
 msgid "The publication has been completed"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:647
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:653
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "A publication for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:667
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:673
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "An approval for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:627
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:633
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "An encoding for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:663
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:669
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Approval started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:624
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:630
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Encoding started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:779
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:785
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "No records found"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:643
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:649
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Publication started in background"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:780
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:786
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Try with a different filter"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:546
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:552
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, approve"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:503
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:509
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, delete record"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:526
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:532
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, encode"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/index.ex:536
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:542
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
 msgid "Yes, publish"
@@ -2789,4 +2789,62 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "An unknown error occurred"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:434
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Approval"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:468
+#, elixir-autogen, elixir-format
+msgid "GBIF IUCN Redlist"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:467
+#, elixir-autogen, elixir-format, fuzzy
+msgid "GBIF Taxonomy"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:471
+#, elixir-autogen, elixir-format
+msgid "Geo Forward"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:470
+#, elixir-autogen, elixir-format
+msgid "Geo Reverse"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:435
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Import"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:433
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Publication"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:469
+#, elixir-autogen, elixir-format
+msgid "Swiss Species"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:441
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:472
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Unknown"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/activity_feed.ex:195
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
+msgid "Unknown activity"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/record/index.ex:398
+#, elixir-autogen, elixir-format, fuzzy
+msgctxt "DataAggregatorWeb.CollectionLive.Record.Index"
+msgid "Encodings"
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -308,7 +308,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Components.Header"
 msgid "Import dataset"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:511
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:517
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Collection Imports"
@@ -493,7 +493,7 @@ msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:123
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:198
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:328
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:334
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapping is invalid"
@@ -520,7 +520,7 @@ msgid "Size"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:104
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:287
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:293
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Started at"
@@ -580,13 +580,13 @@ msgctxt "DataAggregatorWeb.Blocks.EmptyState"
 msgid "No entries"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:525
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:531
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Edit Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:517
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:523
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "New Import"
@@ -652,26 +652,26 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Upload"
 msgid "Please provide your collection file holding your records."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:554
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:560
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Get started by importing a new dataset."
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:169
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:555
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:561
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:535
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import Summary"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:553
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:559
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "No imports"
@@ -756,21 +756,21 @@ msgid "close"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:151
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:356
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:438
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:362
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:444
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Are you sure?"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:150
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:361
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:367
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Delete"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:464
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:470
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import deleted successfully"
@@ -895,7 +895,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.FormComponent"
 msgid "You are not allowed to process an import twice. Please start again by uploading a new import dataset."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:323
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:329
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Column"
@@ -908,7 +908,7 @@ msgid "Created at"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:141
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:318
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:324
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Edit"
@@ -920,19 +920,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Import status and mapping details."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:272
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:278
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Imported"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:331
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:337
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapped to"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:301
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:307
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Mapping"
@@ -970,13 +970,13 @@ msgid "invalid rows:"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/import/index.ex:233
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:282
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:288
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "rows"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:337
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:343
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Unmapped columns"
@@ -2074,22 +2074,22 @@ msgstr ""
 msgid "Download error log"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:397
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:403
 #, elixir-autogen, elixir-format
 msgid "Error message"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:391
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:397
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Field"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:372
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:378
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import Errors"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:406
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:412
 #, elixir-autogen, elixir-format
 msgid "Only the first 100 rows will be shown. Download the file to have the complete log"
 msgstr ""
@@ -2099,7 +2099,7 @@ msgstr ""
 msgid "The selected mapping used by a previous import on this collection is not compatible with the current import file. Please create a new mapping or upload a compatible file."
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:394
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:400
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
@@ -2110,7 +2110,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Error Log"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:267
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:272
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "No errors found"
@@ -2213,12 +2213,12 @@ msgctxt "DataAggregatorWeb.CollectionLive.Publication.Components"
 msgid "Publication to the Gbif Switzerland Portal"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:453
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:459
 #, elixir-autogen, elixir-format
 msgid "An import for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:450
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:456
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import started in background"
 msgstr ""
@@ -2331,7 +2331,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Import.Components.Summary"
 msgid "An import for this collection is already in process"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:439
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:445
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Yes, delete import"
@@ -2749,13 +2749,13 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Publish"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:385
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:391
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Catalog Number"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/import/index.ex:388
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:394
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
 msgid "Scientific Name"
@@ -2783,4 +2783,10 @@ msgstr ""
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Components"
 msgid "Deleting"
+msgstr ""
+
+#: lib/data_aggregator_web/live/collection_live/import/index.ex:269
+#, elixir-autogen, elixir-format
+msgctxt "DataAggregatorWeb.CollectionLive.Import.Index"
+msgid "An unknown error occurred"
 msgstr ""

--- a/test/data_aggregator/records/encoding/gbif_iucn_redlist_encoding_test.exs
+++ b/test/data_aggregator/records/encoding/gbif_iucn_redlist_encoding_test.exs
@@ -58,5 +58,19 @@ defmodule DataAggregator.GbifIUCNRedlistEncodingTest do
 
       assert record.state === :encoded
     end
+
+    @tag capture_log: true
+    test "encode/2 for :gbif_iucn_redlist catalog fails if taxon_id is not provided", %{
+      not_evaluated_record: record
+    } do
+      record = update_record_fixtures!(record, %{tax_taxon_id: nil})
+
+      {{:ok, record}, logs} =
+        with_log(fn -> Record.encode(record, :gbif_iucn_redlist) end)
+
+      assert record.state === :failed
+
+      assert logs =~ "taxon_id is empty"
+    end
   end
 end

--- a/test/data_aggregator/records/encoding/geo_forward_encoding_test.exs
+++ b/test/data_aggregator/records/encoding/geo_forward_encoding_test.exs
@@ -136,7 +136,7 @@ defmodule DataAggregator.ForwardGeoEncodingTest do
           loc_municipality: nil
         })
 
-      {{:error, error}, logs} =
+      {{:ok, _record}, logs} =
         with_log(fn -> Record.encode(record_fixture, :geo_forward) end)
 
       encoded_record =
@@ -156,9 +156,10 @@ defmodule DataAggregator.ForwardGeoEncodingTest do
         loc_municipality: nil
       })
 
-      assert error != nil
       assert encoded_record.record.state === :failed
-      assert logs =~ "The attributes necessary to forward geo encode were not found on record"
+
+      assert logs =~
+               "The attributes necessary to forward geo encode were not found on encoded_record"
     end
   end
 end

--- a/test/data_aggregator/records/encoding/geo_forward_encoding_test.exs
+++ b/test/data_aggregator/records/encoding/geo_forward_encoding_test.exs
@@ -50,7 +50,7 @@ defmodule DataAggregator.ForwardGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        update_fixtures!(record_fixture, %{
+        update_record_fixtures!(record_fixture, %{
           loc_locality: "Niesen",
           loc_continent: nil,
           loc_country: "Switzerland",
@@ -87,7 +87,7 @@ defmodule DataAggregator.ForwardGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        update_fixtures!(record_fixture, %{
+        update_record_fixtures!(record_fixture, %{
           loc_locality: "Europe",
           loc_continent: "Europe",
           loc_country: "Switzerland",
@@ -124,7 +124,7 @@ defmodule DataAggregator.ForwardGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        update_fixtures!(record_fixture, %{
+        update_record_fixtures!(record_fixture, %{
           loc_decimal_latitude: nil,
           loc_decimal_longitude: nil,
           loc_swiss_coordinates_x: nil,
@@ -161,12 +161,5 @@ defmodule DataAggregator.ForwardGeoEncodingTest do
       assert logs =~
                "The attributes necessary to forward geo encode were not found on encoded_record"
     end
-  end
-
-  defp update_fixtures!(record_fixture, update_set) do
-    record_fixture = Record.update!(record_fixture, update_set)
-    encoded_record = EncodedRecord.get_by_record!(record_fixture.id)
-    EncodedRecord.update!(encoded_record, update_set)
-    record_fixture
   end
 end

--- a/test/data_aggregator/records/encoding/geo_forward_encoding_test.exs
+++ b/test/data_aggregator/records/encoding/geo_forward_encoding_test.exs
@@ -50,7 +50,7 @@ defmodule DataAggregator.ForwardGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        Record.update!(record_fixture, %{
+        update_fixtures!(record_fixture, %{
           loc_locality: "Niesen",
           loc_continent: nil,
           loc_country: "Switzerland",
@@ -87,7 +87,7 @@ defmodule DataAggregator.ForwardGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        Record.update!(record_fixture, %{
+        update_fixtures!(record_fixture, %{
           loc_locality: "Europe",
           loc_continent: "Europe",
           loc_country: "Switzerland",
@@ -124,7 +124,7 @@ defmodule DataAggregator.ForwardGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        Record.update!(record_fixture, %{
+        update_fixtures!(record_fixture, %{
           loc_decimal_latitude: nil,
           loc_decimal_longitude: nil,
           loc_swiss_coordinates_x: nil,
@@ -161,5 +161,12 @@ defmodule DataAggregator.ForwardGeoEncodingTest do
       assert logs =~
                "The attributes necessary to forward geo encode were not found on encoded_record"
     end
+  end
+
+  defp update_fixtures!(record_fixture, update_set) do
+    record_fixture = Record.update!(record_fixture, update_set)
+    encoded_record = EncodedRecord.get_by_record!(record_fixture.id)
+    EncodedRecord.update!(encoded_record, update_set)
+    record_fixture
   end
 end

--- a/test/data_aggregator/records/encoding/geo_reverse_encoding_test.exs
+++ b/test/data_aggregator/records/encoding/geo_reverse_encoding_test.exs
@@ -54,7 +54,7 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        update_fixtures!(record_fixture, %{
+        update_record_fixtures!(record_fixture, %{
           loc_decimal_latitude: 32.117833,
           loc_decimal_longitude: 20.082039,
           loc_swiss_coordinates_x: nil,
@@ -88,7 +88,7 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        update_fixtures!(record_fixture, %{
+        update_record_fixtures!(record_fixture, %{
           loc_decimal_latitude: nil,
           loc_decimal_longitude: nil,
           loc_swiss_coordinates_x: 2_601_391.156872048,
@@ -122,7 +122,7 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        update_fixtures!(record_fixture, %{
+        update_record_fixtures!(record_fixture, %{
           loc_decimal_latitude: nil,
           loc_decimal_longitude: nil,
           loc_swiss_coordinates_x: nil,
@@ -156,7 +156,7 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        update_fixtures!(record_fixture, %{
+        update_record_fixtures!(record_fixture, %{
           loc_decimal_latitude: 46.946659297095934,
           loc_decimal_longitude: nil,
           loc_swiss_coordinates_x: 2_601_391.156872048,
@@ -190,7 +190,7 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        update_fixtures!(record_fixture, %{
+        update_record_fixtures!(record_fixture, %{
           loc_decimal_latitude: 4242.4242,
           loc_decimal_longitude: 2424.2424,
           loc_swiss_coordinates_x: nil,
@@ -218,12 +218,5 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
 
       assert logs =~ "No valid response (status 400) from geo api"
     end
-  end
-
-  defp update_fixtures!(record_fixture, update_set) do
-    record_fixture = Record.update!(record_fixture, update_set)
-    encoded_record = EncodedRecord.get_by_record!(record_fixture.id)
-    EncodedRecord.update!(encoded_record, update_set)
-    record_fixture
   end
 end

--- a/test/data_aggregator/records/encoding/geo_reverse_encoding_test.exs
+++ b/test/data_aggregator/records/encoding/geo_reverse_encoding_test.exs
@@ -197,7 +197,7 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
           loc_swiss_coordinates_y: nil
         })
 
-      {{:error, error}, logs} =
+      {{:ok, _record}, logs} =
         with_log(fn -> Record.encode(record_fixture, :geo_reverse) end)
 
       encoded_record = Record.get_by_id!(record_fixture.id)
@@ -215,14 +215,6 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
       })
 
       assert encoded_record.state === :failed
-
-      assert %Ash.Error.Unknown{
-               errors: [
-                 %Ash.Error.Unknown.UnknownError{
-                   error: "No valid response (status 400) from geo api"
-                 }
-               ]
-             } = error
 
       assert logs =~ "No valid response (status 400) from geo api"
     end

--- a/test/data_aggregator/records/encoding/geo_reverse_encoding_test.exs
+++ b/test/data_aggregator/records/encoding/geo_reverse_encoding_test.exs
@@ -54,7 +54,7 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        Record.update!(record_fixture, %{
+        update_fixtures!(record_fixture, %{
           loc_decimal_latitude: 32.117833,
           loc_decimal_longitude: 20.082039,
           loc_swiss_coordinates_x: nil,
@@ -88,7 +88,7 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        Record.update!(record_fixture, %{
+        update_fixtures!(record_fixture, %{
           loc_decimal_latitude: nil,
           loc_decimal_longitude: nil,
           loc_swiss_coordinates_x: 2_601_391.156872048,
@@ -122,7 +122,7 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        Record.update!(record_fixture, %{
+        update_fixtures!(record_fixture, %{
           loc_decimal_latitude: nil,
           loc_decimal_longitude: nil,
           loc_swiss_coordinates_x: nil,
@@ -156,7 +156,7 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        Record.update!(record_fixture, %{
+        update_fixtures!(record_fixture, %{
           loc_decimal_latitude: 46.946659297095934,
           loc_decimal_longitude: nil,
           loc_swiss_coordinates_x: 2_601_391.156872048,
@@ -190,7 +190,7 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
            record_fixture: record_fixture
          } do
       record_fixture =
-        Record.update!(record_fixture, %{
+        update_fixtures!(record_fixture, %{
           loc_decimal_latitude: 4242.4242,
           loc_decimal_longitude: 2424.2424,
           loc_swiss_coordinates_x: nil,
@@ -218,5 +218,12 @@ defmodule DataAggregator.ReverseGeoEncodingTest do
 
       assert logs =~ "No valid response (status 400) from geo api"
     end
+  end
+
+  defp update_fixtures!(record_fixture, update_set) do
+    record_fixture = Record.update!(record_fixture, update_set)
+    encoded_record = EncodedRecord.get_by_record!(record_fixture.id)
+    EncodedRecord.update!(encoded_record, update_set)
+    record_fixture
   end
 end

--- a/test/data_aggregator/records/encoding/swiss_species_encoding_test.exs
+++ b/test/data_aggregator/records/encoding/swiss_species_encoding_test.exs
@@ -88,5 +88,19 @@ defmodule DataAggregator.SwissSpeciesEncodingTest do
 
       assert logs =~ "no encoding strategy found for catalog: :unknown"
     end
+
+    test "encode/2 for :swiss_species catalog fails if taxon_id is not provided", %{
+      correct_record: record
+    } do
+      record = update_record_fixtures!(record, %{tax_taxon_id: nil})
+      Record.encode(record, :swiss_species)
+
+      {{:ok, record}, logs} =
+        with_log(fn -> Record.encode(record, :swiss_species) end)
+
+      assert record.state === :failed
+
+      assert logs =~ "taxon_id is empty"
+    end
   end
 end

--- a/test/data_aggregator/records/encoding/swiss_species_encoding_test.exs
+++ b/test/data_aggregator/records/encoding/swiss_species_encoding_test.exs
@@ -6,7 +6,6 @@ defmodule DataAggregator.SwissSpeciesEncodingTest do
 
   import DataAggregator.EncodingFixtures
 
-  alias Ash.Error.Unknown
   alias DataAggregator.Gbif
   alias DataAggregator.Records.EncodedRecord
   alias DataAggregator.Records.Record
@@ -59,7 +58,7 @@ defmodule DataAggregator.SwissSpeciesEncodingTest do
 
       assert encoded_record.state === :encoded
       assert record != nil
-      assert logs =~ "no matching record found for taxon_id: 0"
+      assert logs =~ "no matching encoded_record found for taxon_id: 0"
     end
 
     test "encode/2 for :swiss_species catalog which returns an error", %{
@@ -67,27 +66,25 @@ defmodule DataAggregator.SwissSpeciesEncodingTest do
     } do
       expect_failing_swiss_species_api_call()
 
-      {{:error, error}, logs} =
+      {{:ok, record}, logs} =
         with_log(fn -> Record.encode(invalid_record, :swiss_species) end)
 
-      assert %Unknown{} = error
+      record = Record.get_by_id!(record.id, load: [:encoded])
 
+      assert record.encoded == false
+      assert logs =~ "Error while encoding the encoded_record"
+      assert logs =~ "with the swiss species catalog: %Ash.Error.Unknown{}"
       assert logs =~ "unknown error occured"
     end
 
     test "encode/2 for :unknown catalog which returns an error", %{
       correct_record: correct_record
     } do
-      {{:error, error}, logs} =
+      {{:ok, record}, logs} =
         with_log(fn -> Record.encode(correct_record, :unknown) end)
 
-      assert %Unknown{
-               errors: [
-                 %Ash.Error.Unknown.UnknownError{
-                   error: "no encoding strategy found for catalog: :unknown"
-                 }
-               ]
-             } = error
+      record = Record.get_by_id!(record.id, load: [:encoded])
+      assert record.encoded == false
 
       assert logs =~ "no encoding strategy found for catalog: :unknown"
     end

--- a/test/data_aggregator/records/encoding/workers/encoder_test.exs
+++ b/test/data_aggregator/records/encoding/workers/encoder_test.exs
@@ -58,6 +58,40 @@ defmodule DataAggregator.Records.Import.Workers.EncoderTest do
       })
     end
 
+    @tag capture_log: true
+    test "succeeds a partial valid record and performs all encodings but sets state to failed", %{
+      correct_record: correct_record
+    } do
+      correct_record = update_record_fixtures!(correct_record, %{loc_country: nil})
+      expect_correct_swiss_species_api_call()
+
+      {:ok, record} = perform_job(Encoder, %{id: correct_record.id})
+
+      assert record.state == :failed
+
+      encoded_record = EncodedRecord.get_by_record!(record.id)
+
+      assert_map_includes(encoded_record, %{
+        tax_class: "Aves",
+        tax_family: "Muscicapidae",
+        tax_genus: "Oenanthe",
+        tax_kingdom: "Animalia",
+        tax_order: "Passeriformes",
+        tax_phylum: "Chordata",
+        tax_scientific_name: "Enantiulus dentigerus (Verhoeff, 1901)",
+        tax_taxon_id: 1_012_187,
+        tax_accepted_name_usage: "Enantiulus dentigerus (Verhoeff, 1901)",
+        tax_taxon_id_ch: 15_311,
+        tax_taxon_rank: "SPECIES",
+        loc_country: nil,
+        loc_municipality: "Bern",
+        loc_state_province: nil,
+        loc_continent: nil,
+        loc_country_code: nil,
+        iucn_redlist_category: "EX"
+      })
+    end
+
     # at the moment there is no failing matchType, we accept all results
     @tag :pending
     test "fails an invalid record to encode", %{invalid_record: invalid_record} do

--- a/test/data_aggregator/records/encoding/workers/encoder_test.exs
+++ b/test/data_aggregator/records/encoding/workers/encoder_test.exs
@@ -8,6 +8,7 @@ defmodule DataAggregator.Records.Import.Workers.EncoderTest do
 
   alias DataAggregator.Gbif
   alias DataAggregator.Opencage
+  alias DataAggregator.Records.EncodedRecord
   alias DataAggregator.Records.Record
   alias DataAggregator.Records.Record.Workers.Encoder
 
@@ -33,6 +34,28 @@ defmodule DataAggregator.Records.Import.Workers.EncoderTest do
       {:ok, record} = perform_job(Encoder, %{id: correct_record.id})
 
       assert record.state == :encoded
+
+      encoded_record = EncodedRecord.get_by_record!(record.id)
+
+      assert_map_includes(encoded_record, %{
+        tax_class: "Aves",
+        tax_family: "Muscicapidae",
+        tax_genus: "Oenanthe",
+        tax_kingdom: "Animalia",
+        tax_order: "Passeriformes",
+        tax_phylum: "Chordata",
+        tax_scientific_name: "Enantiulus dentigerus (Verhoeff, 1901)",
+        tax_taxon_id: 1_012_187,
+        tax_accepted_name_usage: "Enantiulus dentigerus (Verhoeff, 1901)",
+        tax_taxon_id_ch: 15_311,
+        tax_taxon_rank: "SPECIES",
+        loc_country: "Switzerland",
+        loc_municipality: "Bern",
+        loc_state_province: "Bern",
+        loc_continent: "Europe",
+        loc_country_code: "ch",
+        iucn_redlist_category: "EX"
+      })
     end
 
     # at the moment there is no failing matchType, we accept all results

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -3,6 +3,9 @@ defmodule DataAggregator.TestHelpers do
 
   use ExUnit.CaseTemplate
 
+  alias DataAggregator.Records.EncodedRecord
+  alias DataAggregator.Records.Record
+
   using do
     quote do
       import Ash.Test,
@@ -32,5 +35,17 @@ defmodule DataAggregator.TestHelpers do
     quote do
       assert_maps_equal(unquote(actual), unquote(expected), Map.keys(unquote(expected)))
     end
+  end
+
+  @doc """
+  We need to update the record and the encoded record itself. The Strategy.encode/2 function
+  takes the encoded_record from the database which will be set to the record's value during the
+  import process. Thus the fixture needs to be updated in both places to reflect the changes.
+  """
+  def update_record_fixtures!(record_fixture, update_set) do
+    record_fixture = Record.update!(record_fixture, update_set)
+    encoded_record = EncodedRecord.get_by_record!(record_fixture.id)
+    EncodedRecord.update!(encoded_record, update_set)
+    record_fixture
   end
 end


### PR DESCRIPTION
This PR applies the change, that a failed strategy does not abort all encoding.

Closes #391 

## Changes

- do not display empty changes in activity feed
- display error message in import details when validation passed but import crashes
- do not abort encoding if a strategy fails
- properly pass on changes between strategies