### PR TITLE
feat: get collection adn institution data from prod grscicoll

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@
 
 # OPEN_CAGE_DATA_API_KEY=your_api_key
 
+# Use production grscicoll API to get collection and institution data
+# GRSCICOLL_API_BASE_URL=https://api.gbif.org/v1/grscicoll
+
 # GBIF_API_BASE_URL=https://api.gbif-uat.org/v1
 # GBIF_BASE_URL=https://www.gbif-uat.org
 # GBIF_INSTALLATION_KEY=inst-key

--- a/config/.env.prod
+++ b/config/.env.prod
@@ -19,6 +19,9 @@ AWS_S3_HOST=your_S3_HOST
 WAFFLE_S3_BUCKET=your_S3_BUCKET
 WAFFLE_ASSET_HOST=https://${AWS_S3_HOST}/${WAFFLE_S3_BUCKET}
 
+# used for fetching collection and institution data
+GRSCICOLL_API_BASE_URL=https://api.gbif.org/v1/grscicoll
+
 # used for encoding, collection validation and enrichment and registration as
 # well as publication of collections
 GBIF_API_BASE_URL=https://api.gbif.org/v1

--- a/config/.env.test
+++ b/config/.env.test
@@ -9,6 +9,8 @@ WAFFLE_ASSET_HOST=http://localhost:4002
 
 LOG_LEVEL=warning
 
+GRSCICOLL_API_BASE_URL=https://api.gbif.org/v1/grscicoll
+
 GBIF_API_BASE_URL=https://api.gbif-uat.org/v1
 GBIF_BASE_URL=https://www.gbif-uat.org
 

--- a/lib/data_aggregator/api/helpers.ex
+++ b/lib/data_aggregator/api/helpers.ex
@@ -3,6 +3,9 @@ defmodule DataAggregator.Api.Helpers do
   Helper functions for the Data Aggregator API and clients
   """
 
+  @spec grscicoll_api_base_url() :: String.t()
+  def grscicoll_api_base_url, do: System.get_env("GRSCICOLL_API_BASE_URL")
+
   @spec gbif_api_base_url() :: String.t()
   def gbif_api_base_url, do: System.get_env("GBIF_API_BASE_URL")
 
@@ -29,20 +32,20 @@ defmodule DataAggregator.Api.Helpers do
 
   @spec grscicoll_entity_by_key_url(String.t(), atom()) :: String.t()
   def grscicoll_entity_by_key_url(key, :collection) do
-    gbif_api_base_url() <> "/grscicoll/collection/#{key}"
+    grscicoll_api_base_url() <> "/collection/#{key}"
   end
 
   def grscicoll_entity_by_key_url(key, :institution) do
-    gbif_api_base_url() <> "/grscicoll/institution/#{key}"
+    grscicoll_api_base_url() <> "/institution/#{key}"
   end
 
   @spec grscicoll_entities_url(atom()) :: String.t()
   def grscicoll_entities_url(:collection) do
-    gbif_api_base_url() <> "/grscicoll/collection"
+    grscicoll_api_base_url() <> "/collection"
   end
 
   def grscicoll_entities_url(:institution) do
-    gbif_api_base_url() <> "/grscicoll/institution"
+    grscicoll_api_base_url() <> "/institution"
   end
 
   @spec infospecies_approval_notification_url() :: String.t()


### PR DESCRIPTION
We get the institution and collection data from the productive grscicoll api.
So the testers can use up to date data of their institutions / collections