### PR TITLE
fix: don't create LEAKPROOF functions

### DIFF
--- a/priv/repo/migrations/20240807160514_install_ash_functions_extension_4.exs
+++ b/priv/repo/migrations/20240807160514_install_ash_functions_extension_4.exs
@@ -125,7 +125,7 @@ defmodule DataAggregator.Repo.Migrations.InstallAshFunctionsExtension42024080716
       SELECT to_timestamp(('x0000' || substr(_uuid::TEXT, 1, 8) || substr(_uuid::TEXT, 10, 4))::BIT(64)::BIGINT::NUMERIC / 1000);
     $$
     LANGUAGE SQL
-    IMMUTABLE PARALLEL SAFE STRICT LEAKPROOF;
+    IMMUTABLE PARALLEL SAFE STRICT;
     """)
 
     execute("""
@@ -162,7 +162,7 @@ defmodule DataAggregator.Repo.Migrations.InstallAshFunctionsExtension42024080716
       SELECT to_timestamp(('x0000' || substr(_uuid::TEXT, 1, 8) || substr(_uuid::TEXT, 10, 4))::BIT(64)::BIGINT::NUMERIC / 1000);
     $$
     LANGUAGE SQL
-    IMMUTABLE PARALLEL SAFE STRICT LEAKPROOF;
+    IMMUTABLE PARALLEL SAFE STRICT;
     """)
   end
 


### PR DESCRIPTION
this requires to be PG superuser. solution from here: https://elixirforum.com/t/only-superuser-can-define-a-leakproof-function/65486

fixes #442