### PR TITLE
prevent images from beeing downloaded instead of showed in browser

### DIFF
--- a/lib/data_aggregator_web/controllers/image_upload/image_upload_controller.ex
+++ b/lib/data_aggregator_web/controllers/image_upload/image_upload_controller.ex
@@ -10,7 +10,9 @@ defmodule DataAggregatorWeb.ImageUploadController do
         put_status(conn, :not_found)
 
       {:ok, image} ->
-        redirect(conn, external: image.attachment.url)
+        conn
+        |> put_resp_content_type("content-type", "image/jpeg")
+        |> redirect(external: image.attachment.url)
     end
   end
 


### PR DESCRIPTION
explicit set content type to image to prevent the browser from start downloading the image instead of showing it in the browser window