### PR TITLE
on r2 image paths are urls with multiple params

### DIFF
--- a/lib/data_aggregator_web/controllers/image_upload/image_upload_controller.ex
+++ b/lib/data_aggregator_web/controllers/image_upload/image_upload_controller.ex
@@ -86,6 +86,8 @@ defmodule DataAggregatorWeb.ImageUploadController do
 
   defp guess_image_content_type(url) do
     url
+    |> URI.parse()
+    |> Map.get(:path)
     |> Path.extname()
     |> Helpers.accepted_image_content_type()
   end


### PR DESCRIPTION
- on r2 image paths are urls with multiple params - we have to ignore them while detmining the content type
- correct url parsing if url parameters are comming within the image path