### PR TITLE
Fix/csv export linebreaks

### DIFF
--- a/lib/data_aggregator/misc/flat_file_utils.ex
+++ b/lib/data_aggregator/misc/flat_file_utils.ex
@@ -35,7 +35,7 @@ defmodule DataAggregator.Misc.FlatFileUtils do
 
   def map_data_to_headers(record_data, header_fields, nil) do
     Map.new(header_fields, fn {k, v} ->
-      {v, maybe_from_extra_data(record_data, k)}
+      {v, record_data |> maybe_from_extra_data(k) |> maybe_remove_linebreaks()}
     end)
   end
 
@@ -45,9 +45,10 @@ defmodule DataAggregator.Misc.FlatFileUtils do
         {v,
          record_data
          |> maybe_from_extra_data(k)
-         |> transformers[k].()}
+         |> transformers[k].()
+         |> maybe_remove_linebreaks()}
       else
-        {v, maybe_from_extra_data(record_data, k)}
+        {v, record_data |> maybe_from_extra_data(k) |> maybe_remove_linebreaks()}
       end
     end)
   end
@@ -60,7 +61,7 @@ defmodule DataAggregator.Misc.FlatFileUtils do
 
   def map_data_to_headers_list(record_data, header_fields, nil) do
     Enum.map(header_fields, fn k ->
-      maybe_from_extra_data(record_data, k)
+      record_data |> maybe_from_extra_data(k) |> maybe_remove_linebreaks()
     end)
   end
 
@@ -70,8 +71,9 @@ defmodule DataAggregator.Misc.FlatFileUtils do
         record_data
         |> maybe_from_extra_data(k)
         |> transformers[k].()
+        |> maybe_remove_linebreaks()
       else
-        maybe_from_extra_data(record_data, k)
+        record_data |> maybe_from_extra_data(k) |> maybe_remove_linebreaks()
       end
     end)
   end
@@ -83,6 +85,29 @@ defmodule DataAggregator.Misc.FlatFileUtils do
       get_in(record, [:extra_data, stringify(field)])
     end
   end
+
+  @doc ~S"""
+    removes linebreaks from the given value if it is a string
+
+    ## Example
+
+    iex> maybe_remove_linebreaks("foo\nbar")
+    "foo bar"
+
+    iex> maybe_remove_linebreaks("foo\r\nbar")
+    "foo bar"
+
+    iex> maybe_remove_linebreaks("foobar")
+    "foobar"
+
+    iex> maybe_remove_linebreaks(1337)
+    1337
+  """
+  def maybe_remove_linebreaks(value) when is_binary(value) do
+    String.replace(value, ~r/\r?\n/, " ")
+  end
+
+  def maybe_remove_linebreaks(value), do: value
 
   defp stringify(val) when is_atom(val), do: Atom.to_string(val)
   defp stringify(val), do: val

--- a/test/data_aggregator/helpers_test.exs
+++ b/test/data_aggregator/helpers_test.exs
@@ -23,6 +23,7 @@ defmodule DataAggregator.HelpersTest do
   doctest DataAggregator.Records.Encoding.Strategy.ConvertDateHelpers, import: true
   doctest DataAggregator.Records.Encoding.Strategy.GbifTaxonomyStrategy, import: true
   doctest DataAggregator.Taxonomy.Catalogs.SwissSpeciesImporter, import: true
+  doctest DataAggregator.Misc.FlatFileUtils, import: true
 
   setup do
     stub_with(Gbif.RestAPI, Gbif.RestAPIStub)

--- a/test/data_aggregator/records/export/export_test.exs
+++ b/test/data_aggregator/records/export/export_test.exs
@@ -236,8 +236,16 @@ defmodule DataAggregator.ExportTest do
       collection_other = collection_fixture(%{grscicoll_reference: Ecto.UUID.generate()})
 
       # those two should be exported
-      exportable_record(collection, %{extra_data: %{"Custom Attribute" => "Value 1"}})
-      exportable_record(collection, %{extra_data: %{"Custom Attribute" => "Value 2"}})
+      exportable_record(collection, %{
+        extra_data: %{"Custom Attribute" => "Value 1"},
+        mte_verbatim_label: "foo\nbar"
+      })
+
+      exportable_record(collection, %{
+        extra_data: %{"Custom Attribute" => "Value 2"},
+        mte_verbatim_label: nil
+      })
+
       # this one should not be exported
       unexportable_record(collection_other)
 
@@ -340,6 +348,23 @@ defmodule DataAggregator.ExportTest do
       expected = [
         %{"decimalLatitude" => 46.8182, "decimalLongitude" => 640_000},
         %{"decimalLatitude" => 46.8182, "decimalLongitude" => 640_000}
+      ]
+
+      assert expected == transformed_attributes
+    end
+
+    @tag mapping: nil
+    @tag data_layer: :raw
+    @tag header_source: :dwc_attributes
+    test "replaces linebreaks", %{data_frame: data_frame} do
+      rows = Explorer.DataFrame.to_rows(data_frame)
+
+      transformed_attributes =
+        Enum.map(rows, &Map.take(&1, ["verbatimLabel"]))
+
+      expected = [
+        %{"verbatimLabel" => "foo bar"},
+        %{"verbatimLabel" => nil}
       ]
 
       assert expected == transformed_attributes


### PR DESCRIPTION
- [x] fixes [450](https://infofauna-support.atlassian.net/browse/SCN-450)
- [x] doctest and export test to check behaviour

in `FlatFileUtils` whenever we prepare data for export or publication (`map_data_to_headers`, `map_data_to_headers_list`) we replace linebreaks with " " when applicable