### PR TITLE
fix(oth_gbif_id): empty gbif_id after publication

### DIFF
--- a/lib/data_aggregator/darwin_core/schema/schema.ex
+++ b/lib/data_aggregator/darwin_core/schema/schema.ex
@@ -2074,21 +2074,19 @@ defmodule DataAggregator.DarwinCore.Schema do
 
   @categories categories
 
-  @data_from_collection %{
-    oth_gbif_doi: :gbif_doi,
-    oth_gbif_id: :gbif_id,
-    oth_dataset_id: :gbif_dataset_key,
-    oth_institution_id: :grscicoll_institution_key,
-    oth_institution_code: :grscicoll_institution_code,
-    oth_collection_id: :grscicoll_reference,
-    oth_collection_code: :code
-  }
-
   @doc """
   Returns a map to define which fields are not to be taken from the record, but collection
   The key corresponds to the field in the record, the value to the field in the collection
   """
-  def data_from_collection, do: @data_from_collection
+  def data_from_collection,
+    do: %{
+      oth_gbif_doi: :gbif_doi,
+      oth_dataset_id: :gbif_dataset_key,
+      oth_institution_id: :grscicoll_institution_key,
+      oth_institution_code: :grscicoll_institution_code,
+      oth_collection_id: :grscicoll_reference,
+      oth_collection_code: :code
+    }
 
   @doc """
   Returns a map attributes grouped by category.

--- a/lib/data_aggregator/records/record/changes/check_if_fast_track_published.ex
+++ b/lib/data_aggregator/records/record/changes/check_if_fast_track_published.ex
@@ -93,6 +93,6 @@ defmodule DataAggregator.Records.Record.Changes.CheckIfFastTrackPublished do
   defp extract_gbif_id({:ok, response}) do
     occurrence = hd(response.body["results"])
 
-    {:ok, occurrence["gbifID"]}
+    {:ok, occurrence["key"]}
   end
 end

--- a/lib/data_aggregator/records/record/changes/check_if_fast_track_published.ex
+++ b/lib/data_aggregator/records/record/changes/check_if_fast_track_published.ex
@@ -93,6 +93,6 @@ defmodule DataAggregator.Records.Record.Changes.CheckIfFastTrackPublished do
   defp extract_gbif_id({:ok, response}) do
     occurrence = hd(response.body["results"])
 
-    {:ok, occurrence["key"]}
+    {:ok, occurrence["gbifID"]}
   end
 end

--- a/lib/data_aggregator/records/records.ex
+++ b/lib/data_aggregator/records/records.ex
@@ -27,7 +27,7 @@ defmodule DataAggregator.Records do
     execute_async: true,
     image_upload_timeout: :timer.minutes(60),
     extraction_timeout: :timer.minutes(60),
-    mapping_timeout: :timer.hours(1)
+    mapping_timeout: :timer.hours(12)
   ]
 
   authorization do


### PR DESCRIPTION
- [x] fix empty gbif_id on record after publication (should be written down from the gbif api response after publication was started)
- [x] fix oban timeout while mapping images - set to 12h instead of the current value of 1h