### PR TITLE
feat(actions): hide actions based on roles on record view

### DIFF
--- a/lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex
+++ b/lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex
@@ -173,10 +173,9 @@ defmodule DataAggregatorWeb.CollectionLive.Record.Components.Toolbar do
           <ul class="dropdown-content menu menu-sm bg-base-200 rounded-box border-black-white/10 top-px z-10 mt-14 w-44 gap-1 border p-2 shadow-2xl">
             <li :for={{label, icon, action} <- @actions}>
               <button
+                :if={action_allowed?(@current_user, label, @collection)}
                 phx-click={action}
-                disabled={
-                  @busy or is_nil(@meta) or not action_allowed?(@current_user, label, @collection)
-                }
+                disabled={@busy or is_nil(@meta)}
               >
                 <.icon name={icon} class="size-5" />
                 <span class="font-[sans-serif]">{action_label(label)}</span>
@@ -200,10 +199,9 @@ defmodule DataAggregatorWeb.CollectionLive.Record.Components.Toolbar do
         <ul class="dropdown-content menu menu-sm bg-base-200 rounded-box border-black-white/10 top-px z-20 mt-14 w-44 gap-1 border p-2 shadow-2xl">
           <li :for={{label, icon, action} <- @actions}>
             <button
+              :if={action_allowed?(@current_user, label, @collection)}
               phx-click={action}
-              disabled={
-                @busy or is_nil(@meta) or not action_allowed?(@current_user, label, @collection)
-              }
+              disabled={@busy or is_nil(@meta)}
             >
               <.icon name={icon} class="size-5" />
               <span class="font-[sans-serif]">{action_label(label)}</span>
@@ -216,9 +214,10 @@ defmodule DataAggregatorWeb.CollectionLive.Record.Components.Toolbar do
       <div id="actions-xl" class="join max-2xl:hidden">
         <button
           :for={{label, icon, action} <- @actions}
+          :if={action_allowed?(@current_user, label, @collection)}
           class="join-item btn btn-outline border-base-content/20"
           phx-click={action}
-          disabled={@busy or is_nil(@meta) or not action_allowed?(@current_user, label, @collection)}
+          disabled={@busy or is_nil(@meta)}
         >
           <.icon :if={busy?(action, @busy_action) == false} name={icon} />
           <.icon :if={busy?(action, @busy_action)} name="hero-cog-6-tooth-solid animate-spin" />

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1805,19 +1805,19 @@ msgid "Search"
 msgstr "Suchen"
 
 #: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:168
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:197
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:196
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:247
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:246
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Encode"
 msgstr "Enkodieren"
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:246
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:245
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Export"
@@ -1830,7 +1830,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:248
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Publish"
@@ -4223,7 +4223,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Validation status was updated"
 msgstr "Veröffentlichungsstatus wurde aktualisiert"
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:249
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:248
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Validate"
@@ -4470,19 +4470,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:233
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:232
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Encoded Data Layer"
 msgstr "Enkodierte Daten wurden aktualisiert"
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:233
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Imported Data Layer"
 msgstr "Datensatz importieren"
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:232
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:231
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Show validated values"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1805,19 +1805,19 @@ msgid "Search"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:168
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:197
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:196
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Actions"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:247
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:246
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Encode"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:246
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:245
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Export"
@@ -1830,7 +1830,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Filters"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:248
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:247
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Publish"
@@ -4223,7 +4223,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Validation status was updated"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:249
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:248
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Validate"
@@ -4470,19 +4470,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Unknown"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:233
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:232
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Encoded Data Layer"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:233
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Imported Data Layer"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:232
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:231
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Show validated values"

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1805,19 +1805,19 @@ msgid "Search"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:168
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:197
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:196
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Actions"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:247
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:246
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Encode"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:246
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:245
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Export"
@@ -1830,7 +1830,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Filters"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:248
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Publish"
@@ -4223,7 +4223,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Validation status was updated"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:249
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:248
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Validate"
@@ -4470,19 +4470,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Unknown"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:233
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:232
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Encoded Data Layer"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:233
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Imported Data Layer"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:232
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:231
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Show validated values"

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -1805,19 +1805,19 @@ msgid "Search"
 msgstr ""
 
 #: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:168
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:197
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:196
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Actions"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:247
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:246
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Encode"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:246
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:245
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Export"
@@ -1830,7 +1830,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Filters"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:248
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Publish"
@@ -4223,7 +4223,7 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.ActivityFeed"
 msgid "Validation status was updated"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:249
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:248
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Validate"
@@ -4470,19 +4470,19 @@ msgctxt "DataAggregatorWeb.CollectionLive.Record.Components"
 msgid "Unknown"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:233
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:232
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Encoded Data Layer"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:234
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:233
 #, elixir-autogen, elixir-format, fuzzy
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Imported Data Layer"
 msgstr ""
 
-#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:232
+#: lib/data_aggregator_web/live/collection_live/record/components/toolbar.ex:231
 #, elixir-autogen, elixir-format
 msgctxt "DataAggregatorWeb.CollectionLive.Record.Components.Toolbar"
 msgid "Show validated values"


### PR DESCRIPTION
currently not allowed actions are greyed out but they should be invisible according to [SCN-456](https://infofauna-support.atlassian.net/browse/SCN-456):
- [x] hide actions based on roles on record view