### PR TITLE
feat(species_api): use always prod species and match api 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@
 # Use production grscicoll API to get collection and institution data
 # GRSCICOLL_API_BASE_URL=https://api.gbif.org/v1/grscicoll
 
+# GBIF_SPECIES_API_BASE_URL=https://api.gbif.org/v1
 # GBIF_API_BASE_URL=https://api.gbif-uat.org/v1
 # GBIF_BASE_URL=https://www.gbif-uat.org
 # GBIF_INSTALLATION_KEY=inst-key

--- a/config/.env.prod
+++ b/config/.env.prod
@@ -25,6 +25,7 @@ GRSCICOLL_API_BASE_URL=https://api.gbif.org/v1/grscicoll
 # used for encoding, collection validation and enrichment and registration as
 # well as publication of collections
 GBIF_API_BASE_URL=https://api.gbif.org/v1
+GBIF_SPECIES_API_BASE_URL=https://api.gbif.org/v1
 
 # used for linking to the GBIF portal
 GBIF_BASE_URL=https://www.gbif.org

--- a/config/.env.test
+++ b/config/.env.test
@@ -11,6 +11,7 @@ LOG_LEVEL=warning
 
 GRSCICOLL_API_BASE_URL=https://api.gbif.org/v1/grscicoll
 
+GBIF_SPECIES_API_BASE_URL=https://api.gbif.org/v1
 GBIF_API_BASE_URL=https://api.gbif-uat.org/v1
 GBIF_BASE_URL=https://www.gbif-uat.org
 

--- a/lib/data_aggregator/api/helpers.ex
+++ b/lib/data_aggregator/api/helpers.ex
@@ -11,6 +11,9 @@ defmodule DataAggregator.Api.Helpers do
     end
   end
 
+  @spec gbif_species_api_base_url() :: String.t()
+  def gbif_species_api_base_url, do: System.get_env("GBIF_SPECIES_API_BASE_URL")
+
   @spec gbif_api_base_url() :: String.t()
   def gbif_api_base_url, do: System.get_env("GBIF_API_BASE_URL")
 

--- a/lib/data_aggregator/gbif/rest_api.ex
+++ b/lib/data_aggregator/gbif/rest_api.ex
@@ -183,7 +183,7 @@ defmodule DataAggregator.Gbif.RestAPI do
     req = HttpDiskCache.attach(Req.new())
 
     Req.get(req,
-      url: gbif_api_base_url() <> "/species/#{species_key}",
+      url: gbif_species_api_base_url() <> "/species/#{species_key}",
       max_cache_age_seconds: @month
     )
   end
@@ -198,7 +198,7 @@ defmodule DataAggregator.Gbif.RestAPI do
       HttpDiskCache.attach(Req.new(params: params))
 
     Req.get(req,
-      url: gbif_api_base_url() <> "/species/match",
+      url: gbif_species_api_base_url() <> "/species/match",
       max_cache_age_seconds: @month
     )
   end
@@ -247,7 +247,7 @@ defmodule DataAggregator.Gbif.RestAPI do
     req = HttpDiskCache.attach(Req.new())
 
     Req.get(req,
-      url: gbif_api_base_url() <> "/species/" <> key <> "/iucnRedListCategory",
+      url: gbif_species_api_base_url() <> "/species/" <> key <> "/iucnRedListCategory",
       max_cache_age_seconds: @month
     )
   end

--- a/lib/data_aggregator/taxonomy/catalogs/catalog.ex
+++ b/lib/data_aggregator/taxonomy/catalogs/catalog.ex
@@ -31,7 +31,7 @@ defmodule DataAggregator.Taxonomy.Catalog do
       :gbif_iucn_redlist -> "GBIF IUCN Redlist"
       :relate_images -> "Relate Images"
       :convert_dates -> "Date Conversion"
-      _ -> throw("no translation defined for catalog: #{catalog}")
+      _ -> "Unknown"
     end
   end
 


### PR DESCRIPTION
addresses [SCN-488](https://infofauna-support.atlassian.net/jira/software/projects/SCN/boards/3?selectedIssue=SCN-488)
use always prod species and match api  'cause v1 species api is deprecated on UAT

addresses  [SCN-489](https://infofauna-support.atlassian.net/jira/software/projects/SCN/boards/3?selectedIssue=SCN-489)
don't throw if a catalog don't exist. just return title "Unknown"