### PR TITLE
feat(publication-rules): add coordinate obfuscation

### DIFF
--- a/lib/data_aggregator/records/collection/actions/publish.ex
+++ b/lib/data_aggregator/records/collection/actions/publish.ex
@@ -18,6 +18,7 @@ defmodule DataAggregator.Records.Collection.Actions.Publish do
   alias DataAggregator.DarwinCore.Publication.ReleveFile
   alias DataAggregator.DarwinCore.Schema
   alias DataAggregator.Files.Attachment
+  alias DataAggregator.Misc.Coordinates
   alias DataAggregator.Misc.FlatFileUtils
   alias DataAggregator.Records
   alias DataAggregator.Records.Collection
@@ -190,10 +191,11 @@ defmodule DataAggregator.Records.Collection.Actions.Publish do
       {:ok, _result} ->
         Logger.debug("This is a swissSpecies entry. lets use the publication rule to round the data to 2 decimal places")
 
-        # this is a swissSpecies entry. lets use the publication rule
+        {x, y} = obfuscate_coordinates(record.loc_decimal_longitude, record.loc_decimal_latitude)
+
         record
-        |> Map.put(:loc_decimal_latitude, round_coordinates(record.loc_decimal_latitude))
-        |> Map.put(:loc_decimal_longitude, round_coordinates(record.loc_decimal_longitude))
+        |> Map.put(:loc_decimal_longitude, x)
+        |> Map.put(:loc_decimal_latitude, y)
 
       {:error, %NotFound{}} ->
         record
@@ -209,11 +211,35 @@ defmodule DataAggregator.Records.Collection.Actions.Publish do
 
   defp maybe_apply_publication_rules(record), do: record
 
-  defp round_coordinates(value) when is_float(value) do
-    Float.round(value, 2)
+  @doc """
+  Obfuscates the given coordinates to a 5km grid.
+
+  ## Examples
+
+      iex> obfuscate_coordinates(9.166874938, 47.585812401)
+      {9.1338001, 47.5907987}
+
+      iex> obfuscate_coordinates(nil, 47.3769)
+      {nil, 47.3769}
+
+      iex> obfuscate_coordinates(8.5417, nil)
+      {8.5417, nil}
+
+      iex> obfuscate_coordinates(nil, nil)
+      {nil, nil}
+  """
+  def obfuscate_coordinates(x, y) when not is_nil(x) and not is_nil(y) do
+    swiss_coords_lv95 = Coordinates.wgs84_to_lv95!(%Coordinates{e: x, n: y})
+
+    x5 = trunc(swiss_coords_lv95.e / 5000) * 5000 + 2500
+    y5 = trunc(swiss_coords_lv95.n / 5000) * 5000 + 2500
+
+    new_coords = Coordinates.lv95_to_wgs84!(%Coordinates{e: x5, n: y5})
+
+    {Float.round(new_coords.e, 7), Float.round(new_coords.n, 7)}
   end
 
-  defp round_coordinates(value), do: value
+  def obfuscate_coordinates(x, y), do: {x, y}
 
   defp update_count(publication, tenant) do
     # now we update the rows count with the number of records that will be published

--- a/test/data_aggregator/helpers_test.exs
+++ b/test/data_aggregator/helpers_test.exs
@@ -26,6 +26,7 @@ defmodule DataAggregator.HelpersTest do
   doctest DataAggregator.Misc.FlatFileUtils, import: true
   doctest DataAggregator.Records.Record.ExtractAttributesHelpers, import: true
   doctest DataAggregator.Records.ValidationResponse.Helpers, import: true
+  doctest DataAggregator.Records.Collection.Actions.Publish, import: true
 
   setup do
     stub_with(Gbif.RestAPI, Gbif.RestAPIStub)

--- a/test/data_aggregator/records/publication/publication_test.exs
+++ b/test/data_aggregator/records/publication/publication_test.exs
@@ -430,11 +430,11 @@ defmodule DataAggregator.PublicationTest do
       assert_lists_equal(expected, transformed_attributes)
     end
 
-    test "publish/1 succesful with publication rules", %{
+    test "publish/1 succesful with publication rules (coordinate obfuscation)", %{
       publication: publication,
       records: records
     } do
-      expect_correct_swiss_species_api_call(2)
+      expect_correct_swiss_species_api_call(3)
 
       update_record_fixtures!(Enum.at(records, 0), %{
         tax_taxon_id: 4762,
@@ -445,8 +445,15 @@ defmodule DataAggregator.PublicationTest do
       update_record_fixtures!(Enum.at(records, 1), %{
         tax_taxon_id: 4762,
         loc_country: "Switzerland",
-        loc_decimal_latitude: 49.27606815,
-        loc_decimal_longitude: 11.408043484
+        loc_decimal_latitude: 47.585812203,
+        loc_decimal_longitude: 9.166888228
+      })
+
+      update_record_fixtures!(Enum.at(records, 2), %{
+        tax_taxon_id: 4762,
+        loc_country: "Switzerland",
+        loc_decimal_latitude: 47.585812401,
+        loc_decimal_longitude: 9.166874938
       })
 
       update_record_fixtures!(Enum.at(records, 3), %{
@@ -494,16 +501,16 @@ defmodule DataAggregator.PublicationTest do
           "decimalLongitude" => 10.408043484
         },
         %{
-          "decimalLatitude" => 49.28,
-          "decimalLongitude" => 11.41
+          "decimalLatitude" => 47.5898085,
+          "decimalLongitude" => 9.2002562
         },
         %{
-          "decimalLatitude" => 47.27606815,
-          "decimalLongitude" => 9.408043484
+          "decimalLatitude" => 47.5907987,
+          "decimalLongitude" => 9.1338001
         },
         %{
-          "decimalLatitude" => 47.28,
-          "decimalLongitude" => 9.41
+          "decimalLatitude" => 47.2719116,
+          "decimalLongitude" => 9.3880537
         },
         %{
           "decimalLatitude" => nil,


### PR DESCRIPTION
# Pull Request

## Description
Obfuscate coordinates to a 5km grid in the publication rules instead of just rounding the coordinates.

## Related Issue
fixes #842 

## Type of Change
<!-- Mark with an 'x' all that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI update
- [ ] Other (please describe):

## Testing Performed
- changed publication test to test new publication rules
- add doctest to new obfuscation function

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have updated the version number if appropriate
- [x] I understand and agree that my contributions will be licensed under the project's GNU AGPL-3.0 License
