### PR TITLE
db performance issues

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -62,7 +62,7 @@ config :data_aggregator, Oban,
   ],
   queues: [
     imports: 1,
-    encoders: 5,
+    encoders: 2,
     exports: 1,
     publications: 1,
     publication_verifications: 1,

--- a/lib/data_aggregator/records/encoding/changes/select_minimal_fields.ex
+++ b/lib/data_aggregator/records/encoding/changes/select_minimal_fields.ex
@@ -1,0 +1,22 @@
+defmodule DataAggregator.Records.Encoding.Changes.SelectMinimalFields do
+  @moduledoc false
+  use Ash.Resource.Change
+
+  def change(changeset, _opts, _context) do
+    select(changeset)
+  end
+
+  def atomic(changeset, _opts, _context) do
+    {:ok, select(changeset)}
+  end
+
+  defp select(changeset) do
+    Ash.Changeset.select(changeset, [
+      :id,
+      :collection_id,
+      :record_id,
+      :tax_scientific_name,
+      :mte_catalog_number
+    ])
+  end
+end

--- a/lib/data_aggregator/records/encoding/encoded_record.ex
+++ b/lib/data_aggregator/records/encoding/encoded_record.ex
@@ -110,6 +110,10 @@ defmodule DataAggregator.Records.EncodedRecord do
       change Encoding.Changes.SetOptionalAttributes
     end
 
+    update :update_return_minimal_fields do
+      change Encoding.Changes.SelectMinimalFields
+    end
+
     update :add_image_url do
       argument :image, :struct, allow_nil?: false
       require_atomic? false
@@ -127,6 +131,7 @@ defmodule DataAggregator.Records.EncodedRecord do
     define :read
     define :create
     define :update
+    define :update_return_minimal_fields
     define :add_image_url, args: [:image]
     define :destroy
     define :get_by_id, action: :read, get_by: [:id]

--- a/lib/data_aggregator/records/record/changes/remove_associated_media.ex
+++ b/lib/data_aggregator/records/record/changes/remove_associated_media.ex
@@ -34,7 +34,7 @@ defmodule DataAggregator.Records.Record.Image.Changes.RemoveAssociatedMedia do
           |> Enum.reject(fn url -> url == image.image_url end)
           |> Enum.join(" | ")
 
-        EncodedRecord.update!(image.record.encoded_record, %{
+        EncodedRecord.update_return_minimal_fields!(image.record.encoded_record, %{
           mte_associated_media: updated_media_urls
         })
 

--- a/test/data_aggregator/records/encoding/encoded_record_test.exs
+++ b/test/data_aggregator/records/encoding/encoded_record_test.exs
@@ -100,5 +100,35 @@ defmodule DataAggregator.EncodedRecordTest do
     test "destroy/1 with invalid id returns error" do
       assert {:error, %Invalid{}} = EncodedRecord.destroy(%EncodedRecord{id: "invalid"})
     end
+
+    test "update_return_minimal_fields/1 returns only minimal data" do
+      original_encoded_record =
+        encoded_record_fixture(%{tax_family: "Oenantheae", tax_kingdom: "Plantae"})
+
+      encoded_record =
+        EncodedRecord.update_return_minimal_fields!(original_encoded_record, %{
+          tax_family: "new family"
+        })
+
+      assert encoded_record != nil
+
+      # according to Encoding.Changes.SelectMinimalFields --> nsure correct attributes are present and loaded...
+      assert encoded_record.id == original_encoded_record.id
+      assert encoded_record.record_id == original_encoded_record.record_id
+      assert encoded_record.collection_id == original_encoded_record.collection_id
+      assert encoded_record.mte_catalog_number == original_encoded_record.mte_catalog_number
+      assert encoded_record.tax_scientific_name == original_encoded_record.tax_scientific_name
+
+      # ...and not explicitly loaded attributes are not loaded
+      assert encoded_record.tax_family == %Ash.NotLoaded{
+               type: :attribute,
+               field: :tax_family
+             }
+
+      # then reload the record to ensure the updated values are loaded
+      encoded_record = Ash.reload!(encoded_record)
+
+      assert encoded_record.tax_family == "new family"
+    end
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -48,7 +48,7 @@ defmodule DataAggregator.TestHelpers do
     encoded_record =
       EncodedRecord.get_by_record!(record_fixture.id, tenant: record_fixture.collection)
 
-    EncodedRecord.update!(encoded_record, update_set)
+    EncodedRecord.update_return_minimal_fields!(encoded_record, update_set)
     record_fixture
   end
 end


### PR DESCRIPTION
## Description
reduce parallel executed encodings from 5 to 2 to reducebackpressure to the database; introduce
EncodedRecord.update_return_minimal_fields to update an EncodedRecord wo/ returning the full set of 300+ database fields.

this is a first step, but for now we would like to test it if the database still runs out of memory if we only have 2 concurrent encodings.

the second part of `EncodedRecord.update_return_minimal_fields` is an approach of only returning a minimal set of required db fields for update queries on the `encoded_record` table. We could introduce this to lower db memory even more, but this would need some more - major - refactoring within the encoding module.

[db-logs-wip.json](https://github.com/user-attachments/files/22662162/db-logs-wip.json)


## Related Issue
addressing #907

## Type of Change
<!-- Mark with an 'x' all that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test update
- [ ] Build/CI update
- [ ] Other (please describe):

