### PR TITLE
fix: unset collection_id on all attachments of validation responses

### DIFF
--- a/priv/repo/migrations/20260106140023_unset_collection_id_for_validation_responses.exs
+++ b/priv/repo/migrations/20260106140023_unset_collection_id_for_validation_responses.exs
@@ -1,0 +1,25 @@
+defmodule DataAggregator.Repo.Migrations.UnsetCollectionIdForValidationResponses do
+  use Ecto.Migration
+
+  def up do
+    # unset collection_id on all attachments of validation responses, to avoid having them deleted
+    # when cleaning up deleted collection medias
+    execute("""
+      UPDATE file_attachments fa
+      SET collection_id = NULL
+      FROM validation_responses vr
+      JOIN validation_response_2_collections vrc ON vr.id = vrc.validation_response_id
+      WHERE fa.id = vr.error_log_id
+    """)
+  end
+
+  def down do
+    execute("""
+      UPDATE file_attachments fa
+      SET collection_id = vrc.collection_id
+      FROM validation_responses vr
+      JOIN validation_response_2_collections vrc ON vr.id = vrc.validation_response_id
+      WHERE fa.id = vr.error_log_id
+    """)
+  end
+end


### PR DESCRIPTION
## Description
unset collection_id on all attachments of validation responses to avoid having them deleted when cleaning up deleted collection medias

## Type of Change
<!-- Mark with an 'x' all that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI update
- [ ] Other (please describe):
