### PR TITLE
fix: data digitizer needs to be able to create validation requests + small stuff

### DIFF
--- a/lib/data_aggregator/checks/relates_to_institution_check.ex
+++ b/lib/data_aggregator/checks/relates_to_institution_check.ex
@@ -5,6 +5,7 @@ defmodule DataAggregator.Checks.RelatesToInstitutionCheck do
   """
   use Ash.Policy.SimpleCheck
 
+  alias Ash.Policy.Authorizer
   alias Ash.Resource.Actions
 
   @impl true
@@ -28,7 +29,7 @@ defmodule DataAggregator.Checks.RelatesToInstitutionCheck do
     foreign_key = Keyword.fetch!(options, :foreign_key)
     path = Keyword.fetch!(options, :path)
 
-    institution_id = get_institution_id(context.changeset, path, foreign_key, context.action)
+    institution_id = get_institution_id(context, path, foreign_key)
     institution_id == actor_institution_id(actor) || institution_id == nil
   end
 
@@ -36,11 +37,15 @@ defmodule DataAggregator.Checks.RelatesToInstitutionCheck do
   defp actor_institution_id(%{"institution_id" => institution_id}), do: institution_id
   defp actor_institution_id(_), do: nil
 
-  defp get_institution_id(changeset, [], foreign_key, _action) do
+  defp get_institution_id(%Authorizer{changeset: nil, action_input: %Ash.ActionInput{tenant: tenant}}, [], foreign_key) do
+    Map.get(tenant, foreign_key)
+  end
+
+  defp get_institution_id(%Authorizer{changeset: changeset}, [], foreign_key) do
     Ash.Changeset.get_attribute(changeset, foreign_key)
   end
 
-  defp get_institution_id(changeset, path, foreign_key, action) do
+  defp get_institution_id(%Authorizer{changeset: changeset, action: action}, path, foreign_key) do
     [root_key | rest] = path
     rest = rest ++ [foreign_key]
 

--- a/lib/data_aggregator/records/validation_request/validation_request.ex
+++ b/lib/data_aggregator/records/validation_request/validation_request.ex
@@ -242,7 +242,11 @@ defmodule DataAggregator.Records.ValidationRequest do
         authorize_if always()
       end
 
-      policy action_type(:destroy) do
+      policy action_type([:create]) do
+        authorize_if with_role("data_digitizer")
+      end
+
+      policy action_type([:destroy]) do
         authorize_if with_role("collection_administrator")
       end
     end

--- a/priv/repo/migrations/20260106180023_unset_collection_id_for_validation_responses_attachment.exs
+++ b/priv/repo/migrations/20260106180023_unset_collection_id_for_validation_responses_attachment.exs
@@ -2,11 +2,11 @@ defmodule DataAggregator.Repo.Migrations.UnsetCollectionIdForValidationResponses
   use Ecto.Migration
 
   def up do
-    # unset collection_id on all attachments of validation responses, to avoid having them deleted
+    # unset collection_id and deleted_at on all attachments of validation responses, to avoid having them deleted
     # when cleaning up deleted collection medias
     execute("""
     UPDATE file_attachments fa
-    SET collection_id = NULL
+    SET collection_id = NULL, deleted_at = NULL
     FROM validation_responses vr
     JOIN validation_response_2_collections vrc ON vr.id = vrc.validation_response_id
     WHERE fa.id = vr.attachment_id
@@ -14,12 +14,6 @@ defmodule DataAggregator.Repo.Migrations.UnsetCollectionIdForValidationResponses
   end
 
   def down do
-    execute("""
-      UPDATE file_attachments fa
-      SET collection_id = vrc.collection_id
-      FROM validation_responses vr
-      JOIN validation_response_2_collections vrc ON vr.id = vrc.validation_response_id
-      WHERE fa.id = vr.attachment_id
-    """)
+    # data might have changed, no rollback is possible. do it manually.
   end
 end

--- a/priv/repo/migrations/20260106180023_unset_collection_id_for_validation_responses_attachment.exs
+++ b/priv/repo/migrations/20260106180023_unset_collection_id_for_validation_responses_attachment.exs
@@ -11,6 +11,15 @@ defmodule DataAggregator.Repo.Migrations.UnsetCollectionIdForValidationResponses
     JOIN validation_response_2_collections vrc ON vr.id = vrc.validation_response_id
     WHERE fa.id = vr.attachment_id
     """)
+
+    # same for error logs (they are attachments too)
+    execute("""
+    UPDATE file_attachments fa
+    SET collection_id = NULL, deleted_at = NULL
+    FROM validation_responses vr
+    JOIN validation_response_2_collections vrc ON vr.id = vrc.validation_response_id
+    WHERE fa.id = vr.error_log_id
+    """)
   end
 
   def down do

--- a/priv/repo/migrations/20260106180023_unset_collection_id_for_validation_responses_attachment.exs
+++ b/priv/repo/migrations/20260106180023_unset_collection_id_for_validation_responses_attachment.exs
@@ -11,15 +11,6 @@ defmodule DataAggregator.Repo.Migrations.UnsetCollectionIdForValidationResponses
     JOIN validation_response_2_collections vrc ON vr.id = vrc.validation_response_id
     WHERE fa.id = vr.attachment_id OR fa.id = vr.error_log_id
     """)
-
-    # same for error logs (they are attachments too)
-    execute("""
-    UPDATE file_attachments fa
-    SET collection_id = NULL, deleted_at = NULL
-    FROM validation_responses vr
-    JOIN validation_response_2_collections vrc ON vr.id = vrc.validation_response_id
-    WHERE fa.id = vr.error_log_id
-    """)
   end
 
   def down do

--- a/priv/repo/migrations/20260106180023_unset_collection_id_for_validation_responses_attachment.exs
+++ b/priv/repo/migrations/20260106180023_unset_collection_id_for_validation_responses_attachment.exs
@@ -9,7 +9,7 @@ defmodule DataAggregator.Repo.Migrations.UnsetCollectionIdForValidationResponses
     SET collection_id = NULL, deleted_at = NULL
     FROM validation_responses vr
     JOIN validation_response_2_collections vrc ON vr.id = vrc.validation_response_id
-    WHERE fa.id = vr.attachment_id
+    WHERE fa.id = vr.attachment_id OR fa.id = vr.error_log_id
     """)
 
     # same for error logs (they are attachments too)

--- a/priv/repo/migrations/20260106180023_unset_collection_id_for_validation_responses_attachment.exs
+++ b/priv/repo/migrations/20260106180023_unset_collection_id_for_validation_responses_attachment.exs
@@ -1,0 +1,25 @@
+defmodule DataAggregator.Repo.Migrations.UnsetCollectionIdForValidationResponses do
+  use Ecto.Migration
+
+  def up do
+    # unset collection_id on all attachments of validation responses, to avoid having them deleted
+    # when cleaning up deleted collection medias
+    execute("""
+    UPDATE file_attachments fa
+    SET collection_id = NULL
+    FROM validation_responses vr
+    JOIN validation_response_2_collections vrc ON vr.id = vrc.validation_response_id
+    WHERE fa.id = vr.attachment_id
+    """)
+  end
+
+  def down do
+    execute("""
+      UPDATE file_attachments fa
+      SET collection_id = vrc.collection_id
+      FROM validation_responses vr
+      JOIN validation_response_2_collections vrc ON vr.id = vrc.validation_response_id
+      WHERE fa.id = vr.attachment_id
+    """)
+  end
+end

--- a/test/data_aggregator/checks/relates_to_institution_check_test.exs
+++ b/test/data_aggregator/checks/relates_to_institution_check_test.exs
@@ -1,0 +1,206 @@
+defmodule DataAggregator.Checks.RelatesToInstitutionCheckTest do
+  use DataAggregator.DataCase, async: true
+  use Mimic
+
+  alias Ash.Policy.Authorizer
+  alias Ash.Resource.Actions
+  alias DataAggregator.Accounts.User
+  alias DataAggregator.Checks.RelatesToInstitutionCheck
+  alias DataAggregator.Gbif
+  alias DataAggregator.Records.Collection
+
+  describe "describe/1" do
+    test "returns correct description" do
+      assert RelatesToInstitutionCheck.describe(foreign_key: :institution_id, path: []) ==
+               "actor is related to the institution by foreign key institution_id"
+
+      assert RelatesToInstitutionCheck.describe(
+               foreign_key: :grscicoll_institution_key,
+               path: [:collection]
+             ) ==
+               "actor is related to the institution by foreign key collection.grscicoll_institution_key"
+    end
+  end
+
+  describe "requires_original_data?/2" do
+    test "returns false" do
+      refute RelatesToInstitutionCheck.requires_original_data?(nil, nil)
+    end
+  end
+
+  describe "match?/3" do
+    setup do
+      stub_with(Gbif.RestAPI, Gbif.RestAPIStub)
+
+      institution_id = "5b487a79-76ef-4615-93d9-f4ea25a40c33"
+      user = %User{institution_id: institution_id}
+
+      changeset =
+        Ash.Changeset.for_create(Collection, :create, %{
+          grscicoll_institution_key: institution_id,
+          name: "Test Collection",
+          grscicoll_reference: "TEST-REF",
+          type: :botany
+        })
+
+      [changeset: changeset, user: user, institution_id: institution_id]
+    end
+
+    test "returns false when actor is nil" do
+      refute RelatesToInstitutionCheck.match?(nil, %Authorizer{},
+               foreign_key: :grscicoll_institution_key,
+               path: []
+             )
+    end
+
+    test "matches when actor institution_id equals resource key (direct attribute)", %{
+      changeset: changeset,
+      user: actor
+    } do
+      authorizer = %Authorizer{changeset: changeset}
+
+      assert RelatesToInstitutionCheck.match?(actor, authorizer,
+               foreign_key: :grscicoll_institution_key,
+               path: []
+             )
+    end
+
+    test "does not match when ids differ", %{
+      changeset: changeset
+    } do
+      actor = %User{institution_id: Ash.UUID.generate()}
+
+      authorizer = %Authorizer{changeset: changeset}
+
+      refute RelatesToInstitutionCheck.match?(actor, authorizer,
+               foreign_key: :grscicoll_institution_key,
+               path: []
+             )
+    end
+
+    test "matches when resource foreign key is nil", %{
+      changeset: changeset,
+      user: actor
+    } do
+      changeset = Ash.Changeset.force_change_attribute(changeset, :grscicoll_institution_key, nil)
+
+      authorizer = %Authorizer{changeset: changeset}
+
+      assert RelatesToInstitutionCheck.match?(actor, authorizer,
+               foreign_key: :grscicoll_institution_key,
+               path: []
+             )
+    end
+
+    test "matches using Collection as tenant when changeset is nil", %{
+      user: actor,
+      institution_id: institution_id
+    } do
+      tenant = %Collection{grscicoll_institution_key: institution_id}
+
+      authorizer = %Authorizer{
+        changeset: nil,
+        action_input: %Ash.ActionInput{tenant: tenant}
+      }
+
+      assert RelatesToInstitutionCheck.match?(actor, authorizer,
+               foreign_key: :grscicoll_institution_key,
+               path: []
+             )
+    end
+
+    test "matches traversing path for Update action", %{
+      user: actor,
+      institution_id: institution_id
+    } do
+      # Mocking data on changeset for Update
+      data_with_relation = %{
+        collection: %{
+          grscicoll_institution_key: institution_id
+        }
+      }
+
+      changeset = %Ash.Changeset{
+        data: data_with_relation,
+        action_type: :update
+      }
+
+      action = %Actions.Update{}
+      authorizer = %Authorizer{changeset: changeset, action: action}
+
+      assert RelatesToInstitutionCheck.match?(actor, authorizer,
+               foreign_key: :grscicoll_institution_key,
+               path: [:collection]
+             )
+    end
+
+    test "matches traversing path for Destroy action", %{
+      user: actor,
+      institution_id: institution_id
+    } do
+      data_with_relation = %{
+        collection: %{
+          grscicoll_institution_key: institution_id
+        }
+      }
+
+      changeset = %Ash.Changeset{
+        data: data_with_relation,
+        action_type: :destroy
+      }
+
+      action = %Actions.Destroy{}
+      authorizer = %Authorizer{changeset: changeset, action: action}
+
+      assert RelatesToInstitutionCheck.match?(actor, authorizer,
+               foreign_key: :grscicoll_institution_key,
+               path: [:collection]
+             )
+    end
+
+    test "matches traversing path for Create action (using arguments)", %{
+      user: actor,
+      institution_id: institution_id
+    } do
+      arguments = %{
+        collection: %{
+          grscicoll_institution_key: institution_id
+        }
+      }
+
+      changeset = %Ash.Changeset{
+        arguments: arguments,
+        action_type: :create
+      }
+
+      action = %Actions.Create{}
+      authorizer = %Authorizer{changeset: changeset, action: action}
+
+      assert RelatesToInstitutionCheck.match?(actor, authorizer,
+               foreign_key: :grscicoll_institution_key,
+               path: [:collection]
+             )
+    end
+
+    test "matches when path traversal fails (nil encountered)", %{
+      user: actor
+    } do
+      data_with_nil_relation = %{
+        collection: nil
+      }
+
+      changeset = %Ash.Changeset{
+        data: data_with_nil_relation,
+        action_type: :update
+      }
+
+      action = %Actions.Update{}
+      authorizer = %Authorizer{changeset: changeset, action: action}
+
+      assert RelatesToInstitutionCheck.match?(actor, authorizer,
+               foreign_key: :grscicoll_institution_key,
+               path: [:collection]
+             )
+    end
+  end
+end


### PR DESCRIPTION
## Description
data digitizer needs to be able to create validation requests adjust policy check to get institution from tenant, if changeset isn't available; remove collection_id from validation_response related medias;

## Related Issue
#1017 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update
- [ ] Build/CI update
- [ ] Other (please describe):