### PR TITLE
fix(IUCN) always return nil as IUCN catagory if there is no IUCN status 

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -75,7 +75,7 @@ jobs:
 
       - run: mix deps.clean --all
       - run: mix deps.get
-      - run: mix compile
+      - run: mix compile --warnings-as-errors
       - run: rm -rf priv/plts
       - run: mix dialyzer --plt
 
@@ -91,7 +91,6 @@ jobs:
 
       - run: mix assets.setup
       - run: mix assets.build
-      - run: mix compile --warnings-as-errors
       - run: mix lint
       - run: mix test
 

--- a/lib/data_aggregator/records/encoding/strategies/iucn_redlist_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/iucn_redlist_strategy.ex
@@ -107,18 +107,22 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
   defp validate({:iucn_category, body}) do
     additional_status = get_in(body, ["additionalStatus"])
 
-    with false <- is_nil(additional_status),
-         true <- is_list(additional_status),
-         false <- Enum.empty?(additional_status),
-         status = get_correct_status(additional_status),
-         true <- is_map(status),
-         category = get_in(status, ["statusCode"]),
-         true <- is_binary(category) do
-      {:ok, category}
+    if is_nil(additional_status) do
+      {:ok, "NE"}
     else
-      value ->
-        {:error,
-         "Failed to validate IUCN category. Value was: #{inspect(value)}. additionalStatus were: #{inspect(additional_status)}"}
+      with false <- is_nil(additional_status),
+           true <- is_list(additional_status),
+           false <- Enum.empty?(additional_status),
+           status = get_correct_status(additional_status),
+           true <- is_map(status),
+           category = get_in(status, ["statusCode"]),
+           true <- is_binary(category) do
+        {:ok, category}
+      else
+        value ->
+          {:error,
+           "Failed to validate IUCN category. Value was: #{inspect(value)}. additionalStatus were: #{inspect(additional_status)}"}
+      end
     end
   end
 

--- a/lib/data_aggregator/records/encoding/strategies/iucn_redlist_strategy.ex
+++ b/lib/data_aggregator/records/encoding/strategies/iucn_redlist_strategy.ex
@@ -108,7 +108,7 @@ defmodule DataAggregator.Records.Encoding.Strategy.IUCNRedlistStrategy do
     additional_status = get_in(body, ["additionalStatus"])
 
     if is_nil(additional_status) do
-      {:ok, "NE"}
+      {:ok, nil}
     else
       with false <- is_nil(additional_status),
            true <- is_list(additional_status),


### PR DESCRIPTION
# Pull Request

## Description
- [x] always return `nil` as IUCN catagory if there is no IUCN status available
- [x] on ci return warnings as errors


## Related Issue
#1015 

## Type of Change
<!-- Mark with an 'x' all that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI update
- [ ] Other (please describe):